### PR TITLE
Add comparison operators for variant_object

### DIFF
--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -92,6 +92,11 @@ namespace fc
       variant_object& operator=( mutable_variant_object&& );
       variant_object& operator=( const mutable_variant_object& );
 
+      friend bool operator ==( const variant_object& obj1, const variant_object& obj2 );
+      friend bool operator !=( const variant_object& obj1, const variant_object& obj2 ) {
+         return !( obj1 == obj2 );
+      }
+
    private:
       std::shared_ptr< std::vector< entry > > _key_value;
       friend class mutable_variant_object;

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -823,6 +823,7 @@ string      format_string( const string& format, const variant_object& args )
       if( a.is_int64()   || b.is_int64() )  return a.as_int64() == b.as_int64();
       if( a.is_uint64()  || b.is_uint64() ) return a.as_uint64() == b.as_uint64();
       if( a.is_array()   || b.is_array() )  return a.get_array() == b.get_array();
+      if( a.is_object()  || b.is_object() ) return a.get_object() == b.get_object();
       return false;
    }
 

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -164,6 +164,21 @@ namespace fc
    }
 
 
+   bool operator ==( const variant_object& obj1, const variant_object& obj2 ) {
+      auto it1 = obj1.begin();
+      auto it2 = obj2.begin();
+      for ( ; it1 != obj1.end() && it2 != obj2.end(); ++it1, ++it2 ) {
+         if ( *it1 != *it2 )
+            return false;
+      }
+
+      if ( it1 != obj1.end() || it2 != obj2.end() )
+         return false;
+
+      return true;
+   }
+
+
    void to_variant( const variant_object& var,  variant& vo )
    {
       vo = variant(var);


### PR DESCRIPTION
Useful for eosio contract unit tests, when comparing expected rows and actual. Especially when compared objects have nested objects inside them. 