### PR TITLE
Build secp256k1 as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secp256k1/upstream"]
+	path = secp256k1/upstream
+	url = https://github.com/cryptonomex/secp256k1-zkp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,12 @@ endif()
 
 SET (ORIGINAL_LIB_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
 
-find_package(Secp256k1 REQUIRED)
-find_package(GMP REQUIRED)
+add_subdirectory( secp256k1 )
 
 IF( ECC_IMPL STREQUAL openssl )
   SET( ECC_REST src/crypto/elliptic_impl_pub.cpp )
 ELSE( ECC_IMPL STREQUAL openssl )
-  SET( ECC_LIB ${Secp256k1_LIBRARY} ${GMP_LIBRARIES} )
+  SET( ECC_LIB secp256k1 )
   IF( ECC_IMPL STREQUAL mixed )
     SET( ECC_REST src/crypto/elliptic_impl_priv.cpp src/crypto/elliptic_impl_pub.cpp )
   ELSE( ECC_IMPL STREQUAL mixed )
@@ -147,7 +146,6 @@ target_include_directories(fc
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${Boost_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
-    ${Secp256k1_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/vendor/websocketpp
   )
 

--- a/secp256k1/CMakeLists.txt
+++ b/secp256k1/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.4)
+project(secp256k1)
+
+find_package(GMP REQUIRED)
+
+add_library(secp256k1 STATIC
+  upstream/src/secp256k1.c
+)
+
+target_include_directories(secp256k1
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/upstream/
+        ${CMAKE_CURRENT_SOURCE_DIR}/upstream/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/upstream/src
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${GMP_INCLUDE_DIR}
+)
+
+target_compile_definitions(secp256k1 PRIVATE HAVE_CONFIG_H=1)
+
+target_link_libraries(secp256k1 ${GMP_LIBRARIES})

--- a/secp256k1/libsecp256k1-config.h
+++ b/secp256k1/libsecp256k1-config.h
@@ -1,0 +1,21 @@
+#pragma once
+
+//optimizations that any compiler we target have
+#define HAVE_BUILTIN_CLZLL 1
+#define HAVE_BUILTIN_EXPECT 1
+#define HAVE___INT128 1
+
+//use GMP for bignum
+#define HAVE_LIBGMP 1
+#define USE_NUM_GMP 1
+#define USE_FIELD_INV_NUM 1
+#define USE_SCALAR_INV_NUM 1
+
+//use impls best for 64-bit
+#define USE_FIELD_5X52 1
+#define USE_SCALAR_4X64 1
+
+//enable asm
+#ifdef __x86_64__
+  #define USE_ASM_X86_64 1
+#endif


### PR DESCRIPTION
Bundle our secp256k1 library as a submodule. This removes one external dependency (making it a little easier for packaging and future updates), makes the build of secp256k1 use same compiler & flags as the main applications, and fixes a bug where the configure script on macOS wasn’t enabling x86_64 asm operations.