### PR TITLE
delegate static_variant non-const reference constructor to const reference constructor

### DIFF
--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -218,6 +218,7 @@ public:
        );
        static const int value = impl::position<X, Types...>::pos;
     };
+
     static_variant()
     {
        _tag = 0;
@@ -229,10 +230,15 @@ public:
     {
        cpy.visit( impl::copy_construct<static_variant>(*this) );
     }
+
     static_variant( const static_variant& cpy )
     {
        cpy.visit( impl::copy_construct<static_variant>(*this) );
     }
+
+    static_variant( static_variant& cpy )
+    : static_variant( const_cast<const static_variant&>(cpy) )
+    {}
 
     static_variant( static_variant&& mv )
     {
@@ -341,10 +347,10 @@ public:
       try {
          _tag = w;
          impl::storage_ops<0, Types...>::con(_tag, storage);
-      } catch ( ... ) { 
+      } catch ( ... ) {
          _tag = 0;
          impl::storage_ops<0, Types...>::con(_tag, storage);
-      } 
+      }
     }
 
     int which() const {return _tag;}
@@ -364,7 +370,7 @@ struct visitor {
     typedef Result result_type;
 };
 
-   struct from_static_variant 
+   struct from_static_variant
    {
       variant& var;
       from_static_variant( variant& dv ):var(dv){}
@@ -384,7 +390,7 @@ struct visitor {
       typedef void result_type;
       template<typename T> void operator()( T& v )const
       {
-         from_variant( var, v ); 
+         from_variant( var, v );
       }
    };
 


### PR DESCRIPTION
This is to ensure that passing a non-const reference to the constructor does not ever call the forwarding reference constructor (I seems like I somehow ran into this issue with the Ubuntu 16.04 compiler).