### PR TITLE
Fix boost mp num compile error

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -651,7 +651,7 @@ namespace fc
          c.insert( item.as<T>() );
    }
    template<typename T> void to_variant( const boost::multiprecision::number<T>& n, variant& v ) {
-      v = std::string(n);
+      v = n.str();
    }
    template<typename T> void from_variant( const variant& v, boost::multiprecision::number<T>& n ) {
       n = boost::multiprecision::number<T>(v.get_string());


### PR DESCRIPTION
On my clang7, boost 1.68, gnuc++ 8.2.1 environment this line failed to compile. Unknown which of the aforementioned differences may be responsible.

```
/home/spoon/eos/src/libraries/fc/include/fc/variant.hpp:654:11: error: no matching conversion for functional-style cast from 'const boost::multiprecision::number<cpp_
int_backend<128, 128, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >' to 'std::string' (aka 'basic_string<char>')               
      v = std::string(n);                                                                                                                                             
          ^~~~~~~~~~~~~               
/home/spoon/eos/src/libraries/fc/include/fc/variant.hpp:584:7: note: in instantiation of function template specialization 'fc::to_variant<boost::multiprecision::backe
nds::cpp_int_backend<128, 128, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >' requested here                                   
      to_variant( val, *this );                                                                                                                                       
      ^                 
```
Trying {} failed too
```
/home/spoon/eos/src/libraries/fc/include/fc/variant.hpp:654:11: error: no matching constructor for initialization of 'std::string' (aka 'basic_string<char>')
      v = std::string{n};
          ^          ~~~
/home/spoon/eos/src/libraries/fc/include/fc/variant.hpp:584:7: note: in instantiation of function template specialization 'fc::to_variant<boost::multiprecision::backe
nds::cpp_int_backend<128, 128, boost::multiprecision::unsigned_magnitude, boost::multiprecision::unchecked, void> >' requested here
      to_variant( val, *this );
```