### PR TITLE
Log time

### DIFF
--- a/src/log/gelf_appender.cpp
+++ b/src/log/gelf_appender.cpp
@@ -113,7 +113,8 @@ namespace fc
     gelf_message["host"] = my->cfg.host;
     gelf_message["short_message"] = format_string(message.get_format(), message.get_data());
 
-    const auto time_ns = context.get_timestamp().time_since_epoch().count();
+    // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls
+    const auto time_ns = time_point::now().time_since_epoch().count();
     gelf_message["timestamp"] = time_ns / 1000000.;
     gelf_message["_timestamp_ns"] = time_ns;
 


### PR DESCRIPTION
`log_context` is created before the evaluation of log_message format arguments. Therefore if one of the log_message format arguments is a long-running method call, then the log timestamp is an indication of the time of the start of the log message instead of the time the log is actually logged. Since this can confuse debugging, change the console logger and gelf logger to indicate a timestamp closer to the log time instead of the construction of the log_context.