### PR TITLE
Fix time_point to string conversion for large and negative values

### DIFF
--- a/src/time.cpp
+++ b/src/time.cpp
@@ -46,7 +46,8 @@ namespace fc {
    time_point::operator fc::string()const
    {
       auto padded_ms = [](uint64_t ms) {
-         return to_string(ms + 1000ULL).substr(1);
+         uint64_t offset_ms = ms + 1000ULL;
+         return to_string(offset_ms).substr(1);
       };
 
       auto count = elapsed.count();

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -45,22 +45,18 @@ namespace fc {
 
    time_point::operator fc::string()const
    {
-      auto padded_ms = [](uint64_t ms) {
-         uint64_t offset_ms = ms + 1000ULL;
-         return to_string(offset_ms).substr(1);
-      };
-
       auto count = elapsed.count();
       if (count >= 0) {
          uint64_t secs = (uint64_t)count / 1000000ULL;
          uint64_t msec = ((uint64_t)count % 1000000ULL) / 1000ULL;
+         string padded_ms = to_string((uint64_t)(msec + 1000ULL)).substr(1);
          const auto ptime = boost::posix_time::from_time_t(time_t(secs));
-         return boost::posix_time::to_iso_extended_string(ptime) + "." + padded_ms(msec);
+         return boost::posix_time::to_iso_extended_string(ptime) + "." + padded_ms;
       } else {
-         // negative time_points are non-sensical but expressible with the current constraints
-         uint64_t secs = (uint64_t)(-count) / 1000000ULL;
-         uint64_t msec = ((uint64_t)(-count) % 1000000ULL) / 1000ULL;
-         return string("-") + to_string(secs) + "." + padded_ms(msec) + "s";
+         // negative time_points serialized as "durations" in the ISO form with boost
+         // this is not very human readable but fits the precedent set by the above
+         auto as_duration = boost::posix_time::microseconds(count);
+         return boost::posix_time::to_iso_string(as_duration);
       }
    }
 

--- a/src/time.cpp
+++ b/src/time.cpp
@@ -45,20 +45,20 @@ namespace fc {
 
    time_point::operator fc::string()const
    {
-      auto padded_ms = [](auto ms) {
-         return to_string(ms + 1000).substr(1);
+      auto padded_ms = [](uint64_t ms) {
+         return to_string(ms + 1000ULL).substr(1);
       };
 
       auto count = elapsed.count();
       if (count >= 0) {
-         auto secs = count / 1000000LL;
-         auto msec = (count % 1000000LL) / 1000;
+         uint64_t secs = (uint64_t)count / 1000000ULL;
+         uint64_t msec = ((uint64_t)count % 1000000ULL) / 1000ULL;
          const auto ptime = boost::posix_time::from_time_t(time_t(secs));
          return boost::posix_time::to_iso_extended_string(ptime) + "." + padded_ms(msec);
       } else {
          // negative time_points are non-sensical but expressible with the current constraints
-         auto secs = -count / 1000000LL;
-         auto msec = (-count % 1000000LL) / 1000;
+         uint64_t secs = (uint64_t)(-count) / 1000000ULL;
+         uint64_t msec = ((uint64_t)(-count) % 1000000ULL) / 1000ULL;
          return string("-") + to_string(secs) + "." + padded_ms(msec) + "s";
       }
    }


### PR DESCRIPTION
This fixes two issues:

1. time_points which were more than 32bits of seconds from the epoch would wrap due to the silent integer narrowing that happens in `uint32_t time_point::sec_since_epoch() const` as a result those time points would translate to the wrong ISO string.

2. negative time_points are representable due to being composed of the `fc::microsecond` type which can store negative values.  However, these have no representable ISO string so they now degrade to a duration in terms of seconds with 3-digits of precision for millisecond output.  Effectively providing the same base unit as the ISO string (seconds) and the extra resolution.

Note: it is probably worthwhile to consider if changing `::sec_since_epoch() const` and removing the express-ability of negative points in time is worthwhile for `master`.  This is being made against a patch release of a downstream product so, it should not make breaking changes to the data types. 