### PR TITLE
fix pretty_print containing escapes

### DIFF
--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -742,6 +742,11 @@ namespace fc
               break;
             case 'n':
               //If we're in quotes and see a \n, just print it literally but unset the escape flag.
+            case 'b':
+            case 'f':
+            case 'r':
+            case 't':
+            case 'u':
               if( quote && escape )
                 escape = false;
               //No break; fall through to default case


### PR DESCRIPTION
fixes https://github.com/EOSIO/eos/issues/6302, this will handle "escape" with 'n','b','f','r','t','u' correctly.

