### PR TITLE
fc cmake cleanup so it can be used outside of eosio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
-# Setup module path to make visible used CMake extensions
-#INCLUDE(GetPrerequisites)
-#INCLUDE(VersionMacros)
+cmake_minimum_required(VERSION 3.5)
+project(fc)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+include(GNUInstallDirs)
+include(SetupTargetMacros)
 
 SET( DEFAULT_HEADER_INSTALL_DIR usr/include/${target} )
 SET( DEFAULT_LIBRARY_INSTALL_DIR usr/lib )
@@ -15,6 +18,9 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
 endif()
 
 SET (ORIGINAL_LIB_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost 1.67 REQUIRED COMPONENTS date_time filesystem system chrono unit_test_framework)
 
 add_subdirectory( secp256k1 )
 


### PR DESCRIPTION
set the cmakemodule directory correctly so FindGMP.cmake etc can be found; find boost since that's required for fc; gnuinstalldirs needs be included

Work on EOSIO/eos#6381