### PR TITLE
Add verifier call to raw unpack

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -436,6 +436,8 @@ namespace fc {
         template<typename Stream, typename T>
         static inline void unpack( Stream& s, T& v ) {
           if_enum< typename fc::reflector<T>::is_enum >::unpack(s,v);
+           reflector_verifier_visitor<T> verifier(v);
+           verifier.reflector_verify();
         }
       };
 

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -357,9 +357,9 @@ namespace fc {
       };
 
       template<typename Stream, typename Class>
-      struct unpack_object_visitor : fc::reflector_verifier_visitor<Class> {
+      struct unpack_object_visitor : fc::reflector_init_visitor<Class> {
         unpack_object_visitor(Class& _c, Stream& _s)
-        : fc::reflector_verifier_visitor<Class>(_c), s(_s){}
+        : fc::reflector_init_visitor<Class>(_c), s(_s){}
 
         template<typename T, typename C, T(C::*p)>
         inline void operator()( const char* name )const
@@ -436,16 +436,16 @@ namespace fc {
         template<typename Stream, typename T>
         static inline void unpack( Stream& s, T& v ) {
           if_enum< typename fc::reflector<T>::is_enum >::unpack(s,v);
-          // has_feature_reflector_verify_on_unpacked_reflected_types defined below to indicate reflector_verify called
-          reflector_verifier_visitor<T> verifier(v);
-          verifier.reflector_verify();
+          // has_feature_reflector_init_on_unpacked_reflected_types defined below to indicate reflector_init called
+          reflector_init_visitor<T> visitor(v);
+           visitor.reflector_init();
         }
       };
 
     } // namesapce detail
 
-    // allow users to verify version of fc calls reflector_verify on unpacked reflected types
-    constexpr bool has_feature_reflector_verify_on_unpacked_reflected_types = true;
+    // allow users to verify version of fc calls reflector_init on unpacked reflected types
+    constexpr bool has_feature_reflector_init_on_unpacked_reflected_types = true;
 
     template<typename Stream, typename T>
     inline void pack( Stream& s, const std::unordered_set<T>& value ) {

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -436,12 +436,16 @@ namespace fc {
         template<typename Stream, typename T>
         static inline void unpack( Stream& s, T& v ) {
           if_enum< typename fc::reflector<T>::is_enum >::unpack(s,v);
-           reflector_verifier_visitor<T> verifier(v);
-           verifier.reflector_verify();
+          // has_feature_reflector_verify_on_unpacked_reflected_types defined below to indicate reflector_verify called
+          reflector_verifier_visitor<T> verifier(v);
+          verifier.reflector_verify();
         }
       };
 
     } // namesapce detail
+
+    // allow users to verify version of fc calls reflector_verify on unpacked reflected types
+    constexpr bool has_feature_reflector_verify_on_unpacked_reflected_types = true;
 
     template<typename Stream, typename T>
     inline void pack( Stream& s, const std::unordered_set<T>& value ) {

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -148,14 +148,6 @@ static inline void visit( const Visitor& v ) { \
     verify( v ); \
 }
 
-#define FC_REFLECT_DERIVED_IMPL_EXT( TYPE, INHERITS, MEMBERS ) \
-template<typename Visitor>\
-void fc::reflector<TYPE>::visit( const Visitor& v ) { \
-    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
-    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
-    verify( v ); \
-}
-
 #endif // DOXYGEN
 
 
@@ -247,29 +239,6 @@ template<> struct get_typename<ENUM>  { static const char* name()  { return BOOS
  *  @param INHERITS - a sequence of base class names (basea)(baseb)(basec)
  *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
  */
-#define FC_REFLECT_DERIVED( TYPE, INHERITS, MEMBERS ) \
-namespace fc {  \
-  template<> struct get_typename<TYPE>  { static const char* name()  { return BOOST_PP_STRINGIZE(TYPE);  } }; \
-template<> struct reflector<TYPE> {\
-    typedef TYPE type; \
-    typedef fc::true_type  is_defined; \
-    typedef fc::false_type is_enum; \
-    template<typename Visitor> \
-    static auto verify_imp(const Visitor& v, int) -> decltype(v.reflector_verify(), void()) { \
-       v.reflector_verify(); \
-    } \
-    template<typename Visitor> \
-    static auto verify_imp(const Visitor& v, long) -> decltype(v, void()) {} \
-    template<typename Visitor> \
-    static auto verify(const Visitor& v) -> decltype(verify_imp(v, 0), void()) { \
-       verify_imp(v, 0); \
-    } \
-    enum  member_count_enum {  \
-      local_member_count = 0  BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_MEMBER_COUNT, +, MEMBERS ),\
-      total_member_count = local_member_count BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_BASE_MEMBER_COUNT, +, INHERITS )\
-    }; \
-    FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
-}; }
 #define FC_REFLECT_DERIVED_TEMPLATE( TEMPLATE_ARGS, TYPE, INHERITS, MEMBERS ) \
 namespace fc {  \
   template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct get_typename<TYPE>  { static const char* name()  { return BOOST_PP_STRINGIZE(TYPE);  } }; \
@@ -294,6 +263,9 @@ template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> {\
     FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 }; }
 
+#define FC_REFLECT_DERIVED( TYPE, INHERITS, MEMBERS ) \
+   FC_REFLECT_DERIVED_TEMPLATE( (), TYPE, INHERITS, MEMBERS )
+
 //BOOST_PP_SEQ_SIZE(MEMBERS),
 
 /**
@@ -317,26 +289,3 @@ template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> {\
 namespace fc { \
   template<> struct get_typename<TYPE>  { static const char* name()  { return BOOST_PP_STRINGIZE(TYPE);  } }; \
 }
-
-#define FC_REFLECT_FWD( TYPE ) \
-namespace fc { \
-  template<> struct get_typename<TYPE>  { static const char* name()  { return BOOST_PP_STRINGIZE(TYPE);  } }; \
-template<> struct reflector<TYPE> {\
-    typedef TYPE type; \
-    typedef fc::true_type is_defined; \
-    enum  member_count_enum {  \
-      local_member_count = BOOST_PP_SEQ_SIZE(MEMBERS), \
-      total_member_count = local_member_count BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_BASE_MEMBER_COUNT, +, INHERITS )\
-    }; \
-    template<typename Visitor> static void visit( const Visitor& v ); \
-}; }
-
-
-#define FC_REFLECT_DERIVED_IMPL( TYPE, MEMBERS ) \
-    FC_REFLECT_IMPL_DERIVED_EXT( TYPE, BOOST_PP_SEQ_NIL, MEMBERS )
-
-#define FC_REFLECT_IMPL( TYPE, MEMBERS ) \
-    FC_REFLECT_DERIVED_IMPL_EXT( TYPE, BOOST_PP_SEQ_NIL, MEMBERS )
-
-
-

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -94,16 +94,16 @@ struct reflector_verifier_visitor {
 
    // int matches 0 if reflector_verify exists SFINAE
    template<class T>
-   auto verify_imp(const T& t, int) -> decltype(t.reflector_verify(), void()) {
+   auto verify_imp(T& t, int) -> decltype(t.reflector_verify(), void()) {
       t.reflector_verify();
    }
 
    // if no reflector_verify method exists (SFINAE), 0 matches long
    template<class T>
-   auto verify_imp(const T& t, long) -> decltype(t, void()) {}
+   auto verify_imp(T& t, long) -> decltype(t, void()) {}
 
    template<typename T>
-   auto reflect_verify(const T& t) -> decltype(verify_imp(t, 0), void()) {
+   auto reflect_verify(T& t) -> decltype(verify_imp(t, 0), void()) {
       verify_imp(t, 0);
    }
 
@@ -153,6 +153,7 @@ template<typename Visitor>\
 void fc::reflector<TYPE>::visit( const Visitor& v ) { \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
+    verify( v ); \
 }
 
 #endif // DOXYGEN

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -45,15 +45,15 @@ struct reflector{
      *     };
      *    @endcode
      *
-     *  If reflection requires a verification (what a constructor might normally assert) then
-     *  derive your Visitor from reflector_verifier_visitor and implement a reflector_verify()
+     *  If reflection requires an init (what a constructor might normally do) then
+     *  derive your Visitor from reflector_init_visitor and implement a reflector_init()
      *  on your reflected type.
      *
      *    @code
      *     template<typename Class>
-     *     struct functor : reflector_verifier_visitor<Class>  {
+     *     struct functor : reflector_init_visitor<Class>  {
      *        functor(Class& _c)
-     *        : fc::reflector_verifier_visitor<Class>(_c) {}
+     *        : fc::reflector_init_visitor<Class>(_c) {}
      *
      *        template<typename Member, class Class, Member (Class::*member)>
      *        void operator()( const char* name )const;
@@ -82,29 +82,29 @@ void throw_bad_enum_cast( int64_t i, const char* e );
 void throw_bad_enum_cast( const char* k, const char* e );
 
 template <typename Class>
-struct reflector_verifier_visitor {
-   explicit reflector_verifier_visitor( Class& c )
+struct reflector_init_visitor {
+   explicit reflector_init_visitor( Class& c )
      : obj(c) {}
 
-   void reflector_verify() {
-      reflect_verify( obj );
+   void reflector_init() {
+      reflect_init( obj );
    }
 
  private:
 
-   // int matches 0 if reflector_verify exists SFINAE
+   // int matches 0 if reflector_init exists SFINAE
    template<class T>
-   auto verify_imp(T& t, int) -> decltype(t.reflector_verify(), void()) {
-      t.reflector_verify();
+   auto init_imp(T& t, int) -> decltype(t.reflector_init(), void()) {
+      t.reflector_init();
    }
 
-   // if no reflector_verify method exists (SFINAE), 0 matches long
+   // if no reflector_init method exists (SFINAE), 0 matches long
    template<class T>
-   auto verify_imp(T& t, long) -> decltype(t, void()) {}
+   auto init_imp(T& t, long) -> decltype(t, void()) {}
 
    template<typename T>
-   auto reflect_verify(T& t) -> decltype(verify_imp(t, 0), void()) {
-      verify_imp(t, 0);
+   auto reflect_init(T& t) -> decltype(init_imp(t, 0), void()) {
+      init_imp(t, 0);
    }
 
  protected:
@@ -145,7 +145,7 @@ template<typename Visitor>\
 static inline void visit( const Visitor& v ) { \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
-    verify( v ); \
+    init( v ); \
 }
 
 #endif // DOXYGEN
@@ -247,14 +247,14 @@ template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> {\
     typedef fc::true_type  is_defined; \
     typedef fc::false_type is_enum; \
     template<typename Visitor> \
-    static auto verify_imp(const Visitor& v, int) -> decltype(v.reflector_verify(), void()) { \
-       v.reflector_verify(); \
+    static auto init_imp(const Visitor& v, int) -> decltype(v.reflector_init(), void()) { \
+       v.reflector_init(); \
     } \
     template<typename Visitor> \
-    static auto verify_imp(const Visitor& v, long) -> decltype(v, void()) {} \
+    static auto init_imp(const Visitor& v, long) -> decltype(v, void()) {} \
     template<typename Visitor> \
-    static auto verify(const Visitor& v) -> decltype(verify_imp(v, 0), void()) { \
-       verify_imp(v, 0); \
+    static auto init(const Visitor& v) -> decltype(init_imp(v, 0), void()) { \
+       init_imp(v, 0); \
     } \
     enum  member_count_enum {  \
       local_member_count = 0  BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_MEMBER_COUNT, +, MEMBERS ),\

--- a/include/fc/reflect/variant.hpp
+++ b/include/fc/reflect/variant.hpp
@@ -39,11 +39,11 @@ namespace fc
    };
 
    template<typename T>
-   class from_variant_visitor : reflector_verifier_visitor<T>
+   class from_variant_visitor : reflector_init_visitor<T>
    {
       public:
          from_variant_visitor( const variant_object& _vo, T& v )
-         :reflector_verifier_visitor<T>(v)
+         :reflector_init_visitor<T>(v)
          ,vo(_vo){}
 
          template<typename Member, class Class, Member (Class::*member)>


### PR DESCRIPTION
- Call the optional verifier on reflected unpacked types
- Added `has_feature_reflector_verify_on_unpacked_reflected_types`  trait to `fc::raw` so users of `fc::raw::unpack` can depend on this feature.
- This allows classes like the newly refactored `packed_transaction` to perform "construction" needed operations after unpacking.
- Also added missing call to verify for the non-static version of the reflect `visit`.