### PR TITLE
Optimize error logging

### DIFF
--- a/include/fc/log/log_message.hpp
+++ b/include/fc/log/log_message.hpp
@@ -117,6 +117,11 @@ namespace fc
          variant        to_variant()const;
                               
          string         get_message()const;
+         /**
+          * A faster version of get_message which does limited formatting and excludes large variants
+          * @return formatted message according to format and variant args
+          */
+         string         get_limited_message()const;
                               
          log_context    get_context()const;
          string         get_format()const;

--- a/include/fc/string.hpp
+++ b/include/fc/string.hpp
@@ -25,7 +25,7 @@ namespace fc
 
   typedef fc::optional<fc::string> ostring;
   class variant_object;
-  fc::string format_string( const fc::string&, const variant_object& );
+  fc::string format_string( const fc::string&, const variant_object&, bool minimize = false );
   fc::string trim( const fc::string& );
   fc::string to_lower( const fc::string& );
   string trim_and_normalize_spaces( const string& s );

--- a/src/log/log_message.cpp
+++ b/src/log/log_message.cpp
@@ -229,6 +229,12 @@ namespace fc
       return format_string( my->format, my->args );
    }
 
+   string        log_message::get_limited_message()const
+   {
+      const bool minimize = true;
+      return format_string( my->format, my->args, minimize );
+   }
+
 
 } // fc
 

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -766,7 +766,8 @@ constexpr size_t minimize_sub_max_size = minimize_max_size / 4;
 string format_string( const string& frmt, const variant_object& args, bool minimize )
 {
    std::string result;
-   const string& format = frmt.size() > minimize_max_size ? frmt.substr( 0, minimize_max_size ) + "..." : frmt;
+   const string& format = ( minimize && frmt.size() > minimize_max_size ) ?
+         frmt.substr( 0, minimize_max_size ) + "..." : frmt;
    result.reserve( minimize_sub_max_size );
    size_t prev = 0;
    size_t next = format.find( '$' );
@@ -813,7 +814,8 @@ string format_string( const string& frmt, const variant_object& args, bool minim
                   }
                } else if( val->value().is_string() ) {
                   if( minimize && val->value().get_string().size() > minimize_sub_max_size ) {
-                     result += val->value().get_string().substr( 0, minimize_sub_max_size );
+                     auto sz = std::min( minimize_sub_max_size, minimize_max_size - result.size() );
+                     result += val->value().get_string().substr( 0, sz );
                      result += "...";
                   } else {
                      result += val->value().get_string();


### PR DESCRIPTION
- Provide a `log_message::get_limited_message()` that does minimal work to format a log message to optimize logging.
- `get_limit_message` implemented by adding a minimize option to `variant` `format_string`