### PR TITLE
Fix for reflector_init

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -356,7 +356,7 @@ namespace fc {
       };
 
       template<typename Stream, typename Class>
-      struct unpack_object_visitor : fc::reflector_init_visitor<Class> {
+      struct unpack_object_visitor : public fc::reflector_init_visitor<Class> {
         unpack_object_visitor(Class& _c, Stream& _s)
         : fc::reflector_init_visitor<Class>(_c), s(_s){}
 
@@ -435,9 +435,6 @@ namespace fc {
         template<typename Stream, typename T>
         static inline void unpack( Stream& s, T& v ) {
           if_enum< typename fc::reflector<T>::is_enum >::unpack(s,v);
-          // has_feature_reflector_init_on_unpacked_reflected_types defined below to indicate reflector_init called
-          reflector_init_visitor<T> visitor(v);
-           visitor.reflector_init();
         }
       };
 

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -46,12 +46,12 @@ struct reflector{
      *    @endcode
      *
      *  If reflection requires an init (what a constructor might normally do) then
-     *  derive your Visitor from reflector_init_visitor and implement a reflector_init()
+     *  derive your Visitor publicly from reflector_init_visitor and implement a reflector_init()
      *  on your reflected type.
      *
      *    @code
      *     template<typename Class>
-     *     struct functor : reflector_init_visitor<Class>  {
+     *     struct functor : public reflector_init_visitor<Class>  {
      *        functor(Class& _c)
      *        : fc::reflector_init_visitor<Class>(_c) {}
      *
@@ -86,6 +86,9 @@ struct reflector_init_visitor {
    explicit reflector_init_visitor( Class& c )
      : obj(c) {}
 
+   void reflector_init() const {
+      reflect_init( obj );
+   }
    void reflector_init() {
       reflect_init( obj );
    }
@@ -142,10 +145,10 @@ struct reflector_init_visitor {
 
 #define FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 template<typename Visitor>\
-static inline void visit( const Visitor& v ) { \
+static inline void visit( Visitor&& v ) { \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
-    init( v ); \
+    init( std::forward<Visitor>(v) ); \
 }
 
 #endif // DOXYGEN
@@ -247,14 +250,14 @@ template<BOOST_PP_SEQ_ENUM(TEMPLATE_ARGS)> struct reflector<TYPE> {\
     typedef fc::true_type  is_defined; \
     typedef fc::false_type is_enum; \
     template<typename Visitor> \
-    static auto init_imp(const Visitor& v, int) -> decltype(v.reflector_init(), void()) { \
-       v.reflector_init(); \
+    static auto init_imp(Visitor&& v, int) -> decltype(std::forward<Visitor>(v).reflector_init(), void()) { \
+       std::forward<Visitor>(v).reflector_init(); \
     } \
     template<typename Visitor> \
-    static auto init_imp(const Visitor& v, long) -> decltype(v, void()) {} \
+    static auto init_imp(Visitor&& v, long) -> decltype(v, void()) {} \
     template<typename Visitor> \
-    static auto init(const Visitor& v) -> decltype(init_imp(v, 0), void()) { \
-       init_imp(v, 0); \
+    static auto init(Visitor&& v) -> decltype(init_imp(std::forward<Visitor>(v), 0), void()) { \
+       init_imp(std::forward<Visitor>(v), 0); \
     } \
     enum  member_count_enum {  \
       local_member_count = 0  BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_MEMBER_COUNT, +, MEMBERS ),\

--- a/include/fc/reflect/variant.hpp
+++ b/include/fc/reflect/variant.hpp
@@ -39,7 +39,7 @@ namespace fc
    };
 
    template<typename T>
-   class from_variant_visitor : reflector_init_visitor<T>
+   class from_variant_visitor : public reflector_init_visitor<T>
    {
       public:
          from_variant_visitor( const variant_object& _vo, T& v )


### PR DESCRIPTION
- Fix for reflector_init not being called
- private inheritance and const/non-const causing SFINAE to kick in when not desired
- to/from variant was not calling `reflector_init()`
- Explicit call to `reflector_init()` no longer needed for `raw` `fc` `unpack_object_visitor`

Co-authored-by: arhag [arhag@users.noreply.github.com](mailto:arhag@users.noreply.github.com)