### PR TITLE
Fix for reflector_init being called multiple times

### DIFF
--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -120,7 +120,7 @@ struct reflector_init_visitor {
 #ifndef DOXYGEN
 
 #define FC_REFLECT_VISIT_BASE(r, visitor, base) \
-  fc::reflector<base>::visit( visitor );
+  fc::reflector<base>::visit_base( visitor );
 
 
 #ifndef _MSC_VER
@@ -145,9 +145,13 @@ struct reflector_init_visitor {
 
 #define FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 template<typename Visitor>\
+static inline void visit_base( Visitor&& v ) { \
+    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
+} \
+template<typename Visitor>\
 static inline void visit( Visitor&& v ) { \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
-    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
+    visit_base( v ); \
     init( std::forward<Visitor>(v) ); \
 }
 

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -46,15 +46,17 @@ struct reflector{
      *    @endcode
      *
      *  If reflection requires an init (what a constructor might normally do) then
-     *  derive your Visitor publicly from reflector_init_visitor, derive your reflected
+     *  derive your Visitor publicly from fc::reflector_init_visitor, derive your reflected
      *  type from fc::reflect_init and implement a reflector_init() method
      *  on your reflected type. reflector_init() needs to be public or you can friend:
      *     friend struct fc::reflector_init_visitor<your_reflected_class>;
      *     friend struct fc::has_reflector_init<your_reflected_class>;
+     *  Note that if your attributes are also protected/private then you also need:
+     *     friend struct fc::reflector<your_reflected_class>;
      *
      *    @code
      *     template<typename Class>
-     *     struct functor : public reflector_init_visitor<Class>  {
+     *     struct functor : public fc::reflector_init_visitor<Class>  {
      *        functor(Class& _c)
      *        : fc::reflector_init_visitor<Class>(_c) {}
      *

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -114,18 +114,18 @@ struct reflector_init_visitor {
    // 0 matches int if Class derived from reflect_init (SFINAE)
    template<class T>
    typename std::enable_if<std::is_base_of<fc::reflect_init, T>::value>::type
-   init_imp(T& t, int) {
+   init_imp(T& t) {
       t.reflector_init();
    }
 
-   // 0 matches long if Class not derived from reflect_init (SFINAE)
+   // SFINAE if Class not derived from reflect_init
    template<class T>
    typename std::enable_if<not std::is_base_of<fc::reflect_init, T>::value>::type
-   init_imp(T& t, long) {}
+   init_imp(T& t) {}
 
    template<typename T>
-   auto reflect_init(T& t) -> decltype(init_imp(t, 0), void()) {
-      init_imp(t, 0);
+   auto reflect_init(T& t) -> decltype(init_imp(t), void()) {
+      init_imp(t);
    }
 
  protected:

--- a/include/fc/reflect/reflect.hpp
+++ b/include/fc/reflect/reflect.hpp
@@ -146,12 +146,13 @@ struct reflector_init_visitor {
 #define FC_REFLECT_DERIVED_IMPL_INLINE( TYPE, INHERITS, MEMBERS ) \
 template<typename Visitor>\
 static inline void visit_base( Visitor&& v ) { \
+    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
 } \
 template<typename Visitor>\
 static inline void visit( Visitor&& v ) { \
     BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_BASE, v, INHERITS ) \
-    visit_base( v ); \
+    BOOST_PP_SEQ_FOR_EACH( FC_REFLECT_VISIT_MEMBER, v, MEMBERS ) \
     init( std::forward<Visitor>(v) ); \
 }
 


### PR DESCRIPTION
- For FC_REFLECT_DERIVED types reflector_init was being called multiple times on the derived type. All but the last was before all the members had been serialized.
- Added tag type `reflect_init` that derived types can derive from to indicate `reflector_init()` should be called.
- Added `static_assert` to indicate if reflected type derives from tag type `reflect_init` that they also provide the `reflector_init()` method.
- Added `static_assert` to indicate if `reflector_init()` provided that reflected type should be derived from `reflect_init`.
- Unittest added to eos repo