### PR TITLE
Improve serialization bytes from variant

### DIFF
--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -738,8 +738,6 @@ void from_variant( const variant& var,  std::vector<char>& vo )
    const auto& str = var.get_string();
    FC_ASSERT( str.size() <= 2*MAX_SIZE_OF_BYTE_ARRAYS ); // Doubled because hex strings needs two characters per byte
    FC_ASSERT( str.size() % 2 == 0, "the length of hex string should be even number" );
-   if( str.find("0x") != string::npos )
-      str = str.substr(2);
    vo.resize( str.size() / 2 );
    if( vo.size() ) {
       size_t r = from_hex( str, vo.data(), vo.size() );

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -737,10 +737,9 @@ void from_variant( const variant& var,  std::vector<char>& vo )
 {
    const auto& str = var.get_string();
    FC_ASSERT( str.size() <= 2*MAX_SIZE_OF_BYTE_ARRAYS ); // Doubled because hex strings needs two characters per byte
+   FC_ASSERT( str.size() % 2 == 0, "the length of hex string should be even number" );
    if( str.find("0x") != string::npos )
       str = str.substr(2);
-   if( str.size() % 2 )
-      str.insert(0, "0");
    vo.resize( str.size() / 2 );
    if( vo.size() ) {
       size_t r = from_hex( str, vo.data(), vo.size() );

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -737,7 +737,8 @@ void from_variant( const variant& var,  std::vector<char>& vo )
 {
    const auto& str = var.get_string();
    FC_ASSERT( str.size() <= 2*MAX_SIZE_OF_BYTE_ARRAYS ); // Doubled because hex strings needs two characters per byte
-   vo.resize( str.size() / 2 ); {
+   vo.resize( str.size() / 2 );
+   if( vo.size() ) {
       size_t r = from_hex( str, vo.data(), vo.size() );
       FC_ASSERT( r == vo.size() );
    }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -739,6 +739,8 @@ void from_variant( const variant& var,  std::vector<char>& vo )
    FC_ASSERT( str.size() <= 2*MAX_SIZE_OF_BYTE_ARRAYS ); // Doubled because hex strings needs two characters per byte
    if( str.find("0x") != string::npos )
       str = str.substr(2);
+   if( str.size() % 2 )
+      str.insert(0, "0");
    vo.resize( str.size() / 2 );
    if( vo.size() ) {
       size_t r = from_hex( str, vo.data(), vo.size() );

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -737,6 +737,8 @@ void from_variant( const variant& var,  std::vector<char>& vo )
 {
    const auto& str = var.get_string();
    FC_ASSERT( str.size() <= 2*MAX_SIZE_OF_BYTE_ARRAYS ); // Doubled because hex strings needs two characters per byte
+   if( str.find("0x") != string::npos )
+      str = str.substr(2);
    vo.resize( str.size() / 2 );
    if( vo.size() ) {
       size_t r = from_hex( str, vo.data(), vo.size() );


### PR DESCRIPTION
## Changes

* Check bytes size before serialization
Restore check size condition that seems to be deleted by mistake

* Strip `0x` prefix during bytes serialization
Allow hex string for byte array to contain `0x` prefix

* Parse odd-number length hex string during bytes serialization
`1FF` will be serialized as `1F`, because last digit is ignored when the length of string is odd. Unless throwing an exception for odd-length hex string, it had better serialize `1FF` as `01FF` to have intended value.