### PR TITLE
Fix warning, return unknown for invalid log_level

### DIFF
--- a/src/log/log_message.cpp
+++ b/src/log/log_message.cpp
@@ -162,9 +162,7 @@ namespace fc
          case log_level::off:
             return "off";
       }
-#ifdef __GNUC__
-      __builtin_unreachable();
-#endif
+      return "unknown";
    }
 
    string     log_context::get_file()const       { return my->file; }


### PR DESCRIPTION
- Fix warning, return "unknown" for invalid log_level in `to_string`
- Resolves #69 