### PR TITLE
Removing lingering boost::mutex usage from openssl thread support

### DIFF
--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -8,7 +8,6 @@
 
 #include <fc/log/logger.hpp>
 
-#include <boost/thread/mutex.hpp>
 #include <openssl/opensslconf.h>
 #ifndef OPENSSL_THREADS
 # error "OpenSSL must be configured to support threads"
@@ -389,7 +388,7 @@ std::vector<char> aes_load( const fc::path& file, const fc::sha512& key )
 */
 struct openssl_thread_config
 {
-  static boost::mutex* openssl_mutexes;
+  static std::mutex* openssl_mutexes;
   static unsigned long get_thread_id();
   static void locking_callback(int mode, int type, const char *file, int line);
   openssl_thread_config();
@@ -397,7 +396,7 @@ struct openssl_thread_config
 };
 openssl_thread_config openssl_thread_config_manager;
 
-boost::mutex*         openssl_thread_config::openssl_mutexes = nullptr;
+std::mutex*         openssl_thread_config::openssl_mutexes = nullptr;
 
 unsigned long openssl_thread_config::get_thread_id()
 {
@@ -426,7 +425,7 @@ openssl_thread_config::openssl_thread_config()
   if (CRYPTO_get_id_callback() == NULL &&
       CRYPTO_get_locking_callback() == NULL)
   {
-    openssl_mutexes = new boost::mutex[CRYPTO_num_locks()];
+    openssl_mutexes = new std::mutex[CRYPTO_num_locks()];
     CRYPTO_set_id_callback(&get_thread_id);
     CRYPTO_set_locking_callback(&locking_callback);
   }


### PR DESCRIPTION
this deviously hidden code probably needs to be moved to openssl.cpp so we keep all the openssl initialization rigmarole in a single location. Also, it should be ifdef'ed out for openssl 1.1. But I'm not doing that just yet due to being so close to 1.8 release