### PR TITLE
No longer try and static link openssl (and zlib)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,6 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(platformBitness 64)
 endif()
 
-SET (ORIGINAL_LIB_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
-
 add_subdirectory( secp256k1 )
 
 IF( ECC_IMPL STREQUAL openssl )
@@ -31,8 +29,6 @@ ENDIF( ECC_IMPL STREQUAL openssl )
 
 MESSAGE(STATUS "Configuring fc to build on Unix/Apple")
 
-SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
-
 IF(NOT APPLE)
  # Linux or other unix
  SET(rt_library rt )
@@ -46,8 +42,6 @@ IF(NOT "$ENV{OPENSSL_ROOT_DIR}" STREQUAL "")
 ENDIF()
 
 find_package(OpenSSL REQUIRED)
-
-set( CMAKE_FIND_LIBRARY_SUFFIXES ${ORIGINAL_LIB_SUFFIXES} )
 
 set( fc_sources
      src/uint128.cpp


### PR DESCRIPTION
This part of fc's cmake clearly tried to link openssl -- and its zlib dep -- statically. Unfortunately it's clear this doesn't always work: see the ubuntu 18 binaries we've distributed, they have openssl and zlib dynamically linked. But even worse, dynamic vs static seems to be somewhat indeterministic; I saw it switch from dynamic to static on one of my build environments with no explanation.

Let's remove this for now and always link dynamic.

For .debs and .rpms we already indicate we need openssl and zlib as deps (actually the rpm is missing the zlib dep but the openssl-libs package it will get via openssl has a zlib dep).

For mac, we already indicate in our bottle that openssl is required. zlib is system provided.