### PR TITLE
mutable_variant_object: chained operations should preserve rvalueness

### DIFF
--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -5,11 +5,11 @@
 namespace fc
 {
    class mutable_variant_object;
-   
+
    /**
     *  @ingroup Serializable
     *
-    *  @brief An order-perserving dictionary of variant's.  
+    *  @brief An order-preserving dictionary of variants.
     *
     *  Keys are kept in the order they are inserted.
     *  This dictionary implements copy-on-write
@@ -21,7 +21,7 @@ namespace fc
    {
    public:
       /** @brief a key/value pair */
-      class entry 
+      class entry
       {
       public:
          entry();
@@ -30,7 +30,7 @@ namespace fc
          entry( const entry& e);
          entry& operator=(const entry&);
          entry& operator=(entry&&);
-                
+
          const string&        key()const;
          const variant& value()const;
          void  set( variant v );
@@ -43,7 +43,7 @@ namespace fc
          friend bool operator != (const entry& a, const entry& b) {
             return !(a == b);
          }
-             
+
       private:
          string  _key;
          variant _value;
@@ -72,7 +72,7 @@ namespace fc
 
       /** initializes the first key/value pair in the object */
       variant_object( string key, variant val );
-       
+
       template<typename T>
       variant_object( string key, T&& val )
       :_key_value( std::make_shared<std::vector<entry> >() )
@@ -104,7 +104,7 @@ namespace fc
   /**
    *  @ingroup Serializable
    *
-   *  @brief An order-perserving dictionary of variant's.  
+   *  @brief An order-preserving dictionary of variants.
    *
    *  Keys are kept in the order they are inserted.
    *  This dictionary implements copy-on-write
@@ -142,7 +142,7 @@ namespace fc
       /**
          * @name mutable Interface
          *
-         * Calling these methods will result in a copy of the underlying type 
+         * Calling these methods will result in a copy of the underlying type
          * being created if there is more than one reference to this object.
          */
       ///@{
@@ -158,14 +158,16 @@ namespace fc
       iterator             find( const char* key );
 
 
-      /** replaces the value at \a key with \a var or insert's \a key if not found */
-      mutable_variant_object& set( string key, variant var );
-      /** Appends \a key and \a var without checking for duplicates, designed to
-         *  simplify construction of dictionaries using (key,val)(key2,val2) syntax 
+      /** replaces the value at \a key with \a var or inserts \a key if not found */
+      mutable_variant_object& set( string key, variant var ) &;
+      mutable_variant_object&& set( string key, variant var ) &&;
+
+     /** Appends \a key and \a var without checking for duplicates, designed to
+         *  simplify construction of dictionaries using (key,val)(key2,val2) syntax
          */
       /**
       *  Convenience method to simplify the manual construction of
-      *  variant_object's
+      *  variant_objects
       *
       *  Instead of:
       *    <code>mutable_variant_object("c",c).set("a",a).set("b",b);</code>
@@ -175,21 +177,30 @@ namespace fc
       *
       *  @return *this;
       */
-      mutable_variant_object& operator()( string key, variant var );
+      mutable_variant_object& operator()( string key, variant var ) &;
+      mutable_variant_object&& operator()( string key, variant var ) &&;
       template<typename T>
-      mutable_variant_object& operator()( string key, T&& var )
+      mutable_variant_object& operator()( string key, T&& var ) &
       {
          set(std::move(key), variant( fc::forward<T>(var) ) );
          return *this;
       }
+      template<typename T>
+      mutable_variant_object&& operator()( string key, T&& var ) &&
+      {
+         set(std::move(key), variant( fc::forward<T>(var) ) );
+         return std::move(*this);
+      }
       /**
        * Copy a variant_object into this mutable_variant_object.
        */
-      mutable_variant_object& operator()( const variant_object& vo );
+      mutable_variant_object& operator()( const variant_object& vo )&;
+      mutable_variant_object&& operator()( const variant_object& vo )&&;
       /**
        * Copy another mutable_variant_object into this mutable_variant_object.
        */
-      mutable_variant_object& operator()( const mutable_variant_object& mvo );
+      mutable_variant_object& operator()( const mutable_variant_object& mvo ) &;
+      mutable_variant_object&& operator()( const mutable_variant_object& mvo ) &&;
       ///@}
 
 

--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -160,7 +160,7 @@ namespace fc
 
       /** replaces the value at \a key with \a var or inserts \a key if not found */
       mutable_variant_object& set( string key, variant var ) &;
-      mutable_variant_object&& set( string key, variant var ) &&;
+      mutable_variant_object set( string key, variant var ) &&;
 
      /** Appends \a key and \a var without checking for duplicates, designed to
          *  simplify construction of dictionaries using (key,val)(key2,val2) syntax
@@ -178,7 +178,7 @@ namespace fc
       *  @return *this;
       */
       mutable_variant_object& operator()( string key, variant var ) &;
-      mutable_variant_object&& operator()( string key, variant var ) &&;
+      mutable_variant_object operator()( string key, variant var ) &&;
       template<typename T>
       mutable_variant_object& operator()( string key, T&& var ) &
       {
@@ -186,7 +186,7 @@ namespace fc
          return *this;
       }
       template<typename T>
-      mutable_variant_object&& operator()( string key, T&& var ) &&
+      mutable_variant_object operator()( string key, T&& var ) &&
       {
          set(std::move(key), variant( fc::forward<T>(var) ) );
          return std::move(*this);
@@ -194,13 +194,13 @@ namespace fc
       /**
        * Copy a variant_object into this mutable_variant_object.
        */
-      mutable_variant_object& operator()( const variant_object& vo )&;
-      mutable_variant_object&& operator()( const variant_object& vo )&&;
+      mutable_variant_object& operator()( const variant_object& vo ) &;
+      mutable_variant_object operator()( const variant_object& vo ) &&;
       /**
        * Copy another mutable_variant_object into this mutable_variant_object.
        */
       mutable_variant_object& operator()( const mutable_variant_object& mvo ) &;
-      mutable_variant_object&& operator()( const mutable_variant_object& mvo ) &&;
+      mutable_variant_object operator()( const mutable_variant_object& mvo ) &&;
       ///@}
 
 

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -341,7 +341,7 @@ namespace fc
       return *this;
    }
 
-   mutable_variant_object&& mutable_variant_object::set( string key, variant var ) &&
+   mutable_variant_object mutable_variant_object::set( string key, variant var ) &&
    {
       auto itr = find( key.c_str() );
       if( itr != end() )
@@ -364,7 +364,7 @@ namespace fc
       return *this;
    }
 
-   mutable_variant_object&& mutable_variant_object::operator()( string key, variant var ) &&
+   mutable_variant_object mutable_variant_object::operator()( string key, variant var ) &&
    {
       _key_value->push_back( entry( fc::move(key), fc::move(var) ) );
       return std::move(*this);
@@ -377,7 +377,7 @@ namespace fc
       return *this;
    }
 
-   mutable_variant_object&& mutable_variant_object::operator()( const variant_object& vo ) &&
+   mutable_variant_object mutable_variant_object::operator()( const variant_object& vo ) &&
    {
       for( const variant_object::entry& e : vo )
          set( e.key(), e.value() );
@@ -393,7 +393,7 @@ namespace fc
       return *this;
    }
 
-   mutable_variant_object&& mutable_variant_object::operator()( const mutable_variant_object& mvo ) &&
+   mutable_variant_object mutable_variant_object::operator()( const mutable_variant_object& mvo ) &&
    {
       for( const mutable_variant_object::entry& e : mvo )
          set( e.key(), e.value() );

--- a/src/variant_object.cpp
+++ b/src/variant_object.cpp
@@ -327,7 +327,7 @@ namespace fc
    }
 
    /** replaces the value at \a key with \a var or insert's \a key if not found */
-   mutable_variant_object& mutable_variant_object::set( string key, variant var )
+   mutable_variant_object& mutable_variant_object::set( string key, variant var ) &
    {
       auto itr = find( key.c_str() );
       if( itr != end() )
@@ -341,29 +341,63 @@ namespace fc
       return *this;
    }
 
+   mutable_variant_object&& mutable_variant_object::set( string key, variant var ) &&
+   {
+      auto itr = find( key.c_str() );
+      if( itr != end() )
+      {
+         itr->set( fc::move(var) );
+      }
+      else
+      {
+         _key_value->push_back( entry( fc::move(key), fc::move(var) ) );
+      }
+      return std::move(*this);
+   }
+
    /** Appends \a key and \a var without checking for duplicates, designed to
     *  simplify construction of dictionaries using (key,val)(key2,val2) syntax
     */
-   mutable_variant_object& mutable_variant_object::operator()( string key, variant var )
+   mutable_variant_object& mutable_variant_object::operator()( string key, variant var ) &
    {
       _key_value->push_back( entry( fc::move(key), fc::move(var) ) );
       return *this;
    }
 
-   mutable_variant_object& mutable_variant_object::operator()( const variant_object& vo )
+   mutable_variant_object&& mutable_variant_object::operator()( string key, variant var ) &&
+   {
+      _key_value->push_back( entry( fc::move(key), fc::move(var) ) );
+      return std::move(*this);
+   }
+
+   mutable_variant_object& mutable_variant_object::operator()( const variant_object& vo ) &
    {
       for( const variant_object::entry& e : vo )
          set( e.key(), e.value() );
       return *this;
    }
 
-   mutable_variant_object& mutable_variant_object::operator()( const mutable_variant_object& mvo )
+   mutable_variant_object&& mutable_variant_object::operator()( const variant_object& vo ) &&
+   {
+      for( const variant_object::entry& e : vo )
+         set( e.key(), e.value() );
+      return std::move(*this);
+   }
+
+   mutable_variant_object& mutable_variant_object::operator()( const mutable_variant_object& mvo ) &
    {
       if( &mvo == this )     // mvo(mvo) is no-op
          return *this;
       for( const mutable_variant_object::entry& e : mvo )
          set( e.key(), e.value() );
       return *this;
+   }
+
+   mutable_variant_object&& mutable_variant_object::operator()( const mutable_variant_object& mvo ) &&
+   {
+      for( const mutable_variant_object::entry& e : mvo )
+         set( e.key(), e.value() );
+      return std::move(*this);
    }
 
    void to_variant( const mutable_variant_object& var,  variant& vo )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory( crypto )
+add_subdirectory( variant )

--- a/test/variant/CMakeLists.txt
+++ b/test/variant/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable( test_variant test_variant.cpp )
+target_link_libraries( test_variant fc ${Boost_LIBRARIES})
+
+add_test(NAME test_variant COMMAND libraries/fc/test/variant/test_variant WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/variant/test_variant.cpp
+++ b/test/variant/test_variant.cpp
@@ -1,0 +1,34 @@
+#define BOOST_TEST_MODULE variant
+#include <boost/test/unit_test.hpp>
+
+#include <fc/variant_object.hpp>
+#include <fc/exception/exception.hpp>
+
+#include <string>
+
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(variant_test_suite)
+BOOST_AUTO_TEST_CASE(mutable_variant_object_test)
+{
+  // no BOOST_CHECK / BOOST_REQUIRE, just see that this compiles on all supported platforms
+  try {
+    variant v(42);
+    variant_object vo;
+    mutable_variant_object mvo;
+    variants vs;
+    vs.push_back(mutable_variant_object("level", "debug")("color", v));
+    vs.push_back(mutable_variant_object()("level", "debug")("color", v));
+    vs.push_back(mutable_variant_object("level", "debug")("color", "green"));
+    vs.push_back(mutable_variant_object()("level", "debug")("color", "green"));
+    vs.push_back(mutable_variant_object("level", "debug")(vo));
+    vs.push_back(mutable_variant_object()("level", "debug")(mvo));
+    vs.push_back(mutable_variant_object("level", "debug").set("color", v));
+    vs.push_back(mutable_variant_object()("level", "debug").set("color", v));
+    vs.push_back(mutable_variant_object("level", "debug").set("color", "green"));
+    vs.push_back(mutable_variant_object()("level", "debug").set("color", "green"));
+  }
+  FC_LOG_AND_RETHROW();
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Follow-up to #83 
Also cleans up some comments and whitespace in variant_object.hpp