### PR TITLE
mutable_variant_object fix for GCC 7 - v1.6.x

### DIFF
--- a/include/fc/variant_object.hpp
+++ b/include/fc/variant_object.hpp
@@ -193,7 +193,9 @@ namespace fc
       ///@}
 
 
-      template<typename T>
+      template<typename T,
+               typename = std::enable_if_t<!std::is_base_of<mutable_variant_object,
+                                                            std::decay_t<T>>::value>>
       explicit mutable_variant_object( T&& v )
       :_key_value( new std::vector<entry>() )
       {


### PR DESCRIPTION
Make sure mutable_variant_object's templated constructor doesn't get called to make a copy.

Issue seen on GCC 7 -std=c++1z