### PR TITLE
add/fix support for comparison operators to static_variant 

### DIFF
--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -102,7 +102,7 @@ struct storage_ops<R, N, T, Ts...> {
 
     template<template<typename> class Op>
     static R apply_binary_operator(int n, const void *lhs, const void *rhs) {
-       if (n == N) return Op<T>()(*reinterpret_cast<const T*>(lhs), *reinterpret_cast<const T*>(rhs));
+       if (n == N) return Op<void>()(*reinterpret_cast<const T*>(lhs), *reinterpret_cast<const T*>(rhs));
        else return storage_ops<R, N + 1, Ts...>::template apply_binary_operator<Op>(n, lhs, rhs);
     }
 };
@@ -164,23 +164,13 @@ struct type_at<Pos, T, Ts...> {
 };
 
 template<template<typename> class Op, typename T>
-std::is_convertible<std::invoke_result_t<Op<T>, const T&, const T&>, bool> can_invoke_operator_test(int);
+std::is_convertible<std::invoke_result_t<Op<void>, const T&, const T&>, bool> can_invoke_operator_test(int);
 
 template<template<typename> class Op, typename T>
 std::false_type can_invoke_operator_test(...);
 
 template<template<typename> class Op, typename T>
 using can_invoke_operator = decltype(can_invoke_operator_test<Op, T>(0));
-
-template<class T>
-using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
-
-template<class T>
-using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
-
-template<class T>
-using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
-
 
 template<typename T, typename... Ts>
 struct type_info<T&, Ts...> {
@@ -367,8 +357,8 @@ public:
     template <typename Bool = bool>
     friend std::enable_if_t<type_info::has_not_equal_to, Bool> operator != ( const static_variant& a, const static_variant& b )
     {
-       if (a.which() == b.which()) {
-          return false;
+       if (a.which() != b.which()) {
+          return true;
        }
 
        return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::not_equal_to>(a._tag, a.storage, b.storage);

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -377,8 +377,12 @@ public:
     template <typename Bool = bool>
     friend std::enable_if_t<type_info::has_less, Bool> operator < ( const static_variant& a, const static_variant& b )
     {
-       if (a.which() >= b.which()) {
+       if (a.which() > b.which()) {
           return false;
+       }
+
+       if (a.which() < b.which()) {
+          return true;
        }
 
        return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::less>(a._tag, a.storage, b.storage);
@@ -391,14 +395,22 @@ public:
           return false;
        }
 
+       if (a.which() < b.which()) {
+          return true;
+       }
+
        return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::less_equal>(a._tag, a.storage, b.storage);
     }
 
     template <typename Bool = bool>
     friend std::enable_if_t<type_info::has_greater, Bool> operator > ( const static_variant& a, const static_variant& b )
     {
-       if (a.which() <= b.which()) {
+       if (a.which() < b.which()) {
           return false;
+       }
+
+       if (a.which() > b.which()) {
+          return true;
        }
 
        return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::greater>(a._tag, a.storage, b.storage);
@@ -411,6 +423,10 @@ public:
           return false;
        }
 
+       if (a.which() > b.which()) {
+          return true;
+       }
+       
        return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::greater_equal>(a._tag, a.storage, b.storage);
     }
 

--- a/include/fc/static_variant.hpp
+++ b/include/fc/static_variant.hpp
@@ -72,6 +72,9 @@ struct storage_ops<R, N, T&, Ts...> {
 
     template<typename visitor>
     static R apply(int n, const void *data, visitor&& v) {}
+
+    template<template<typename> class Op>
+    static R apply_binary_operator(int n, const void *lhs, const void *rhs) {}
 };
 
 template<typename R, int N, typename T, typename... Ts>
@@ -97,6 +100,11 @@ struct storage_ops<R, N, T, Ts...> {
         else return storage_ops<R, N + 1, Ts...>::apply(n, data, std::forward<visitor>(v));
     }
 
+    template<template<typename> class Op>
+    static R apply_binary_operator(int n, const void *lhs, const void *rhs) {
+       if (n == N) return Op<T>()(*reinterpret_cast<const T*>(lhs), *reinterpret_cast<const T*>(rhs));
+       else return storage_ops<R, N + 1, Ts...>::template apply_binary_operator<Op>(n, lhs, rhs);
+    }
 };
 
 template<typename R, int N>
@@ -114,6 +122,11 @@ struct storage_ops<R, N> {
     }
     template<typename visitor>
     static R apply(int n, const void *data, visitor&& v) {
+       FC_THROW_EXCEPTION( fc::assert_exception, "Internal error: static_variant tag is invalid." );
+    }
+
+    template<template<typename> class Op>
+    static R apply_binary_operator(int n, const void *lhs, const void *rhs) {
        FC_THROW_EXCEPTION( fc::assert_exception, "Internal error: static_variant tag is invalid." );
     }
 };
@@ -150,12 +163,38 @@ struct type_at<Pos, T, Ts...> {
    using type = typename type_at<Pos - 1, Ts...>::type;
 };
 
+template<template<typename> class Op, typename T>
+std::is_convertible<std::invoke_result_t<Op<T>, const T&, const T&>, bool> can_invoke_operator_test(int);
+
+template<template<typename> class Op, typename T>
+std::false_type can_invoke_operator_test(...);
+
+template<template<typename> class Op, typename T>
+using can_invoke_operator = decltype(can_invoke_operator_test<Op, T>(0));
+
+template<class T>
+using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
+
+template<class T>
+using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
+
+template<class T>
+using has_equal_to_v = typename can_invoke_operator<std::equal_to, T>::value;
+
+
 template<typename T, typename... Ts>
 struct type_info<T&, Ts...> {
     static const bool no_reference_types = false;
     static const bool no_duplicates = position<T, Ts...>::pos == -1 && type_info<Ts...>::no_duplicates;
     static const size_t size = type_info<Ts...>::size > sizeof(T&) ? type_info<Ts...>::size : sizeof(T&);
     static const size_t count = 1 + type_info<Ts...>::count;
+
+    static const bool has_equal_to = can_invoke_operator<std::equal_to, std::remove_reference_t<T>>::value && type_info<Ts...>::has_equal_to;
+    static const bool has_not_equal_to = can_invoke_operator<std::not_equal_to, std::remove_reference_t<T>>::value && type_info<Ts...>::has_not_equal_to;
+    static const bool has_less = can_invoke_operator<std::less, std::remove_reference_t<T>>::value && type_info<Ts...>::has_less;
+    static const bool has_less_equal = can_invoke_operator<std::less_equal, std::remove_reference_t<T>>::value && type_info<Ts...>::has_less_equal;
+    static const bool has_greater = can_invoke_operator<std::greater, std::remove_reference_t<T>>::value && type_info<Ts...>::has_greater;
+    static const bool has_greater_equal = can_invoke_operator<std::greater_equal, std::remove_reference_t<T>>::value && type_info<Ts...>::has_greater_equal;
 };
 
 template<typename T, typename... Ts>
@@ -164,6 +203,13 @@ struct type_info<T, Ts...> {
     static const bool no_duplicates = position<T, Ts...>::pos == -1 && type_info<Ts...>::no_duplicates;
     static const size_t size = type_info<Ts...>::size > sizeof(T) ? type_info<Ts...>::size : sizeof(T&);
     static const size_t count = 1 + type_info<Ts...>::count;
+
+    static const bool has_equal_to = can_invoke_operator<std::equal_to, T>::value && type_info<Ts...>::has_equal_to;
+    static const bool has_not_equal_to = can_invoke_operator<std::not_equal_to, T>::value && type_info<Ts...>::has_not_equal_to;
+    static const bool has_less = can_invoke_operator<std::less, T>::value && type_info<Ts...>::has_less;
+    static const bool has_less_equal = can_invoke_operator<std::less_equal, T>::value && type_info<Ts...>::has_less_equal;
+    static const bool has_greater = can_invoke_operator<std::greater, T>::value && type_info<Ts...>::has_greater;
+    static const bool has_greater_equal = can_invoke_operator<std::greater_equal, T>::value && type_info<Ts...>::has_greater_equal;
 };
 
 template<>
@@ -172,6 +218,12 @@ struct type_info<> {
     static const bool no_duplicates = true;
     static const size_t count = 0;
     static const size_t size = 0;
+    static const bool has_equal_to = true;
+    static const bool has_not_equal_to = true;
+    static const bool has_less = true;
+    static const bool has_less_equal = true;
+    static const bool has_greater = true;
+    static const bool has_greater_equal = true;
 };
 
 template<typename Visitor, typename T>
@@ -209,8 +261,9 @@ struct result_type_info<Visitor, T, Ts...> {
 
 template<typename... Types>
 class static_variant {
-    static_assert(impl::type_info<Types...>::no_reference_types, "Reference types are not permitted in static_variant.");
-    static_assert(impl::type_info<Types...>::no_duplicates, "static_variant type arguments contain duplicate types.");
+    using type_info = impl::type_info<Types...>;
+    static_assert(type_info::no_reference_types, "Reference types are not permitted in static_variant.");
+    static_assert(type_info::no_duplicates, "static_variant type arguments contain duplicate types.");
 
     alignas(Types...) char storage[impl::type_info<Types...>::size];
     int _tag;
@@ -300,13 +353,65 @@ public:
        v.visit( impl::move_construct<static_variant>(*this) );
        return *this;
     }
-    friend bool operator == ( const static_variant& a, const static_variant& b )
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_equal_to, Bool> operator == ( const static_variant& a, const static_variant& b )
     {
-       return a.which() == b.which();
+       if (a.which() != b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::equal_to>(a._tag, a.storage, b.storage);
     }
-    friend bool operator < ( const static_variant& a, const static_variant& b )
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_not_equal_to, Bool> operator != ( const static_variant& a, const static_variant& b )
     {
-       return a.which() < b.which();
+       if (a.which() == b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::not_equal_to>(a._tag, a.storage, b.storage);
+    }
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_less, Bool> operator < ( const static_variant& a, const static_variant& b )
+    {
+       if (a.which() >= b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::less>(a._tag, a.storage, b.storage);
+    }
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_less_equal, Bool> operator <= ( const static_variant& a, const static_variant& b )
+    {
+       if (a.which() > b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::less_equal>(a._tag, a.storage, b.storage);
+    }
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_greater, Bool> operator > ( const static_variant& a, const static_variant& b )
+    {
+       if (a.which() <= b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::greater>(a._tag, a.storage, b.storage);
+    }
+
+    template <typename Bool = bool>
+    friend std::enable_if_t<type_info::has_greater_equal, Bool> operator >= ( const static_variant& a, const static_variant& b )
+    {
+       if (a.which() < b.which()) {
+          return false;
+       }
+
+       return impl::storage_ops<bool, 0, Types...>::template apply_binary_operator<std::greater_equal>(a._tag, a.storage, b.storage);
     }
 
     template<typename X>
@@ -359,7 +464,7 @@ public:
         return impl::storage_ops<R, 0, Types...>::apply(_tag, storage, std::forward<visitor>(v));
     }
 
-    static uint32_t count() { return impl::type_info<Types...>::count; }
+    static uint32_t count() { return type_info::count; }
     void set_which( uint32_t w ) {
       FC_ASSERT( w < count()  );
       this->~static_variant();
@@ -380,7 +485,7 @@ public:
     template<typename X>
     static constexpr int position() { return impl::position<X, Types...>::pos; }
 
-    template<int Pos, std::enable_if_t<Pos < impl::type_info<Types...>::size,int> = 1>
+    template<int Pos, std::enable_if_t<Pos < type_info::size,int> = 1>
     using type_at = typename impl::type_at<Pos, Types...>::type;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory( crypto )
+add_subdirectory( static_variant )
 add_subdirectory( variant )

--- a/test/static_variant/CMakeLists.txt
+++ b/test/static_variant/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable( test_static_variant test_static_variant.cpp)
+target_link_libraries( test_static_variant fc ${Boost_LIBRARIES})
+
+add_test(NAME test_static_variant COMMAND libraries/fc/test/static_variant/test_static_variant WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/static_variant/test_static_variant.cpp
+++ b/test/static_variant/test_static_variant.cpp
@@ -1,0 +1,184 @@
+#define BOOST_TEST_MODULE static_variant
+#include <boost/test/unit_test.hpp>
+
+#include <fc/static_variant.hpp>
+#include <fc/exception/exception.hpp>
+
+using namespace fc;
+
+template<bool Eq = false, bool Neq = false, bool Lt = false, bool Lte = false, bool Gt= false, bool Gte = false>
+struct comparable_type {
+
+   int value;
+
+   template<bool Enabled = Eq, typename = std::enable_if_t<Enabled>>
+   bool operator== (const comparable_type& other ) const {
+      return value == other.value;
+   }
+
+   template<bool Enabled = Neq, typename = std::enable_if_t<Enabled>>
+   bool operator!= (const comparable_type& other ) const {
+      return value != other.value;
+   }
+
+   template<bool Enabled = Lt, typename = std::enable_if_t<Enabled>>
+   bool operator< (const comparable_type& other ) const {
+      return value < other.value;
+   }
+
+   template<bool Enabled = Lte, typename = std::enable_if_t<Enabled>>
+   bool operator<= (const comparable_type& other ) const {
+      return value <= other.value;
+   }
+
+   template<bool Enabled = Gt, typename = std::enable_if_t<Enabled>>
+   bool operator> (const comparable_type& other ) const {
+      return value > other.value;
+   }
+
+   template<bool Enabled = Gte, typename = std::enable_if_t<Enabled>>
+   bool operator>= (const comparable_type& other ) const {
+      return value >= other.value;
+   }
+};
+
+template<template<typename> class Op, typename Variant>
+std::is_convertible<std::invoke_result_t<Op<void>, const Variant&, const Variant&>, bool> variant_has_op_test(int);
+
+template<template<typename> class Op, typename Variant>
+std::false_type variant_has_op_test(...);
+
+template<template<typename> class Op, typename Variant>
+constexpr bool variant_has_op_v = decltype(variant_has_op_test<Op, Variant>(0))::value;
+
+using not_comparable = comparable_type<>;
+using full_comparable = comparable_type<true, true, true, true, true, true>;
+using eq_only  = comparable_type<true>;
+using neq_only = comparable_type<false, true>;
+using lt_only  = comparable_type<false, false, true>;
+using lte_only = comparable_type<false, false, false, true>;
+using gt_only  = comparable_type<false, false, false, false, true>;
+using gte_only = comparable_type<false, false, false, false, false, true>;
+
+BOOST_AUTO_TEST_SUITE(static_variant_test_suite)
+   BOOST_AUTO_TEST_CASE(test_eq)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::equal_to, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::equal_to, static_variant<eq_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::equal_to, static_variant<eq_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::equal_to, static_variant<eq_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) == static_variant<full_comparable>(full_comparable{1})  ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) == static_variant<full_comparable>(full_comparable{2})) ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE(( !(static_variant<full_comparable, eq_only>(full_comparable{1}) == static_variant<full_comparable, eq_only>(eq_only{1})) ));
+   }
+
+   BOOST_AUTO_TEST_CASE(test_neq)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::not_equal_to, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::not_equal_to, static_variant<neq_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::not_equal_to, static_variant<neq_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::not_equal_to, static_variant<neq_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) != static_variant<full_comparable>(full_comparable{2})  ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) != static_variant<full_comparable>(full_comparable{1})) ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE(( static_variant<full_comparable, neq_only>(full_comparable{1}) != static_variant<full_comparable, neq_only>(neq_only{1}) ));
+   }
+
+   BOOST_AUTO_TEST_CASE(test_lt)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::less, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::less, static_variant<lt_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::less, static_variant<lt_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::less, static_variant<lt_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) < static_variant<full_comparable>(full_comparable{2})  ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) < static_variant<full_comparable>(full_comparable{1})) ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) < static_variant<full_comparable>(full_comparable{0})) ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE((   static_variant<full_comparable, lt_only>(full_comparable{1}) < static_variant<full_comparable, lt_only>(lt_only{1})          ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable, lt_only>(full_comparable{1}) < static_variant<full_comparable, lt_only>(full_comparable{1})) ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable, lt_only>(lt_only{1})         < static_variant<full_comparable, lt_only>(full_comparable{1})) ));
+   }
+
+   BOOST_AUTO_TEST_CASE(test_lte)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::less_equal, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::less_equal, static_variant<lte_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::less_equal, static_variant<lte_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::less_equal, static_variant<lte_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) <= static_variant<full_comparable>(full_comparable{2})  ));
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) <= static_variant<full_comparable>(full_comparable{1})  ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) <= static_variant<full_comparable>(full_comparable{0})) ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE((   static_variant<full_comparable, lte_only>(full_comparable{1}) <= static_variant<full_comparable, lte_only>(lte_only{1})         ));
+      BOOST_REQUIRE((   static_variant<full_comparable, lte_only>(full_comparable{1}) <= static_variant<full_comparable, lte_only>(full_comparable{1})  ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable, lte_only>(lte_only{1})        <= static_variant<full_comparable, lte_only>(full_comparable{1})) ));
+   }
+
+   BOOST_AUTO_TEST_CASE(test_gt)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::greater, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::greater, static_variant<gt_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::greater, static_variant<gt_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::greater, static_variant<gt_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) > static_variant<full_comparable>(full_comparable{2})) ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) > static_variant<full_comparable>(full_comparable{1})) ));
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) > static_variant<full_comparable>(full_comparable{0})  ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE(( !(static_variant<full_comparable, gt_only>(full_comparable{1}) > static_variant<full_comparable, gt_only>(gt_only{1}))         ));
+      BOOST_REQUIRE(( !(static_variant<full_comparable, gt_only>(full_comparable{1}) > static_variant<full_comparable, gt_only>(full_comparable{1})) ));
+      BOOST_REQUIRE((   static_variant<full_comparable, gt_only>(gt_only{1})         > static_variant<full_comparable, gt_only>(full_comparable{1})  ));
+   }
+
+   BOOST_AUTO_TEST_CASE(test_gte)
+   {
+      // ensure that the given comparisons are present IFF the types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::greater_equal, static_variant<not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::greater_equal, static_variant<gte_only> > ));
+
+      // ensure that given comparisons are present IFF the ALL types support it
+      BOOST_REQUIRE(( !variant_has_op_v<std::greater_equal, static_variant<gte_only, not_comparable> > ));
+      BOOST_REQUIRE(( variant_has_op_v<std::greater_equal, static_variant<gte_only, full_comparable> > ));
+
+      // ensure the operator returns expected values
+      BOOST_REQUIRE(( !(static_variant<full_comparable>(full_comparable{1}) >= static_variant<full_comparable>(full_comparable{2})) ));
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) >= static_variant<full_comparable>(full_comparable{1})  ));
+      BOOST_REQUIRE((   static_variant<full_comparable>(full_comparable{1}) >= static_variant<full_comparable>(full_comparable{0})  ));
+
+      // ensure the operator respects binary equivalent but different types
+      BOOST_REQUIRE(( !(static_variant<full_comparable, gte_only>(full_comparable{1}) >= static_variant<full_comparable, gte_only>(gte_only{1}))        ));
+      BOOST_REQUIRE((   static_variant<full_comparable, gte_only>(full_comparable{1}) >= static_variant<full_comparable, gte_only>(full_comparable{1})  ));
+      BOOST_REQUIRE((   static_variant<full_comparable, gte_only>(gte_only{1})        >= static_variant<full_comparable, gte_only>(full_comparable{1})  ));
+   }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Previously `fc::static_variant` has implementations of `operator ==` and `operator <` that only compared the type information and did not compare the enclosed values. 

This PR adds type information that detects whether all of the constituent types support various standard operator functions (including when supported through constructs like `std::is_equal` rather than a plain `operator ==` for instance).  

This type information is used to control visibility of the operators which compare the type discriminator and when equal compare the enclosed values.  These operators are only present when ALL constituent types support some form of the operator:

supported operators:

- `operator ==`
- `operator !=`
- `operator <`
- `operator <=`
- `operator >`
- `operator >=`

