### PR TITLE
Fix certificate trust when trust settings is empty

### DIFF
--- a/src/network/platform_root_ca.cpp
+++ b/src/network/platform_root_ca.cpp
@@ -52,7 +52,9 @@ static void add_macos_root_cas(boost::asio::ssl::context& ctx) {
             }
             if(trustSettings == nullptr)
                continue;
-            for(CFIndex k = 0; k < CFArrayGetCount(trustSettings); k++) {
+            if(CFArrayGetCount(trustSettings) == 0)
+               trust_as_root = true;
+            else for(CFIndex k = 0; k < CFArrayGetCount(trustSettings); k++) {
                CFNumberRef cfNum;
                CFDictionaryRef tSetting = (CFDictionaryRef)CFArrayGetValueAtIndex(trustSettings, k);
                if(CFDictionaryGetValueIfPresent(tSetting, kSecTrustSettingsResult, (const void**)&cfNum)){


### PR DESCRIPTION
When a certificate has no trust settings it is to be trusted

See https://developer.apple.com/documentation/security/1400261-sectrustsettingscopytrustsetting?language=objc

>An empty trust settings array (that is, the trustSettings parameter returns a valid but empty CFArray) means "always trust this certificate” with an overall trust setting for the certificate of kSecTrustSettingsResultTrustRoot. Note that an empty trust settings array is not the same as no trust settings (the trustSettings parameter returns NULL), which means "this certificate must be verified to a known trusted certificate”.