### PR TITLE
Thread safe log config

### DIFF
--- a/include/fc/log/appender.hpp
+++ b/include/fc/log/appender.hpp
@@ -36,15 +36,6 @@ namespace fc {
       public:
          typedef std::shared_ptr<appender> ptr;
 
-         template<typename T>
-         static bool register_appender(const fc::string& type) {
-            return register_appender( type, std::make_shared<detail::appender_factory_impl<T>>() );
-         }
-
-         static appender::ptr create( const fc::string& name, const fc::string& type, const variant& args  );
-         static appender::ptr get( const fc::string& name );
-         static bool          register_appender( const fc::string& type, const appender_factory::ptr& f );
-
          virtual void initialize( boost::asio::io_service& io_service ) = 0;
          virtual void log( const log_message& m ) = 0;
    };

--- a/include/fc/log/logger.hpp
+++ b/include/fc/log/logger.hpp
@@ -22,6 +22,7 @@ namespace fc
    {
       public:
          static logger get( const fc::string& name = "default");
+         static void update( const fc::string& name, logger& log );
 
          logger();
          logger( const string& name, const logger& parent = nullptr );
@@ -42,12 +43,12 @@ namespace fc
          void  set_name( const fc::string& n );
          const fc::string& name()const;
 
-         void add_appender( const std::shared_ptr<appender>& a );
-         std::vector<std::shared_ptr<appender> > get_appenders()const;
-         void remove_appender( const std::shared_ptr<appender>& a );
-
          bool is_enabled( log_level e )const;
          void log( log_message m );
+
+      private:
+         friend struct log_config;
+         void add_appender( const std::shared_ptr<appender>& a );
 
       private:
          class impl;

--- a/src/log/appender.cpp
+++ b/src/log/appender.cpp
@@ -1,48 +1,13 @@
 #include <fc/log/appender.hpp>
-#include <fc/log/logger.hpp>
-#include <unordered_map>
-#include <string>
 #include <fc/log/console_appender.hpp>
 #include <fc/log/gelf_appender.hpp>
-#include <fc/variant.hpp>
-#include <mutex>
-#include "console_defines.h"
+#include <fc/log/logger_config.hpp>
 
 
 namespace fc {
 
-   std::unordered_map<std::string,appender::ptr>& get_appender_map() {
-     static std::unordered_map<std::string,appender::ptr> lm;
-     return lm;
-   }
-   std::unordered_map<std::string,appender_factory::ptr>& get_appender_factory_map() {
-     static std::unordered_map<std::string,appender_factory::ptr> lm;
-     return lm;
-   }
-   appender::ptr appender::get( const fc::string& s ) {
-      static std::mutex appender_mutex;
-      std::lock_guard<std::mutex> lock(appender_mutex);
-      return get_appender_map()[s];
-   }
-   bool  appender::register_appender( const fc::string& type, const appender_factory::ptr& f )
-   {
-      get_appender_factory_map()[type] = f;
-      return true;
-   }
-   appender::ptr appender::create( const fc::string& name, const fc::string& type, const variant& args  )
-   {
-      auto fact_itr = get_appender_factory_map().find(type);
-      if( fact_itr == get_appender_factory_map().end() ) {
-         //wlog( "Unknown appender type '%s'", type.c_str() );
-         return appender::ptr();
-      }
-      auto ap = fact_itr->second->create( args );
-      get_appender_map()[name] = ap;
-      return ap;
-   }
-
-   static bool reg_console_appender = appender::register_appender<console_appender>( "console" );
+   static bool reg_console_appender = log_config::register_appender<console_appender>( "console" );
    //static bool reg_file_appender = appender::register_appender<file_appender>( "file" );
-   static bool reg_gelf_appender = appender::register_appender<gelf_appender>( "gelf" );
+   static bool reg_gelf_appender = log_config::register_appender<gelf_appender>( "gelf" );
 
 } // namespace fc

--- a/src/log/console_appender.cpp
+++ b/src/log/console_appender.cpp
@@ -19,7 +19,6 @@ namespace fc {
    class console_appender::impl {
    public:
      config                      cfg;
-     std::mutex                  log_mutex;
      color::type                 lc[log_level::off+1];
      bool                        use_syslog_header{getenv("JOURNAL_STREAM")};
 #ifdef WIN32
@@ -141,8 +140,6 @@ namespace fc {
       }
       line += "] ";
       line += fc::format_string( m.get_format(), m.get_data() );
-
-      std::unique_lock<std::mutex> lock(my->log_mutex);
 
       print( line, my->lc[context.get_log_level()] );
 

--- a/src/log/gelf_appender.cpp
+++ b/src/log/gelf_appender.cpp
@@ -12,7 +12,6 @@
 #include <boost/lexical_cast.hpp>
 #include <iomanip>
 #include <iostream>
-#include <mutex>
 #include <queue>
 #include <sstream>
 #include <iostream>
@@ -33,7 +32,6 @@ namespace fc
     config                                    cfg;
     optional<boost::asio::ip::udp::endpoint>  gelf_endpoint;
     udp_socket                                gelf_socket;
-    std::mutex                                gelf_log_mutex;
 
     impl(const config& c) :
       cfg(c)
@@ -163,8 +161,6 @@ namespace fc
         gelf_message_as_string[1] == (char)0xda)
       gelf_message_as_string[1] = (char)0x9c;
     FC_ASSERT(gelf_message_as_string[1] == (char)0x9c);
-
-    std::unique_lock<std::mutex> lock(my->gelf_log_mutex);
 
     // packets are sent by UDP, and they tend to disappear if they
     // get too large.  It's hard to find any solid numbers on how

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -59,30 +59,28 @@ namespace fc {
     }
 
     void logger::log( log_message m ) {
+       std::unique_lock g( log_config::get().log_mutex );
        m.get_context().append_context( my->_name );
 
        for( auto itr = my->_appenders.begin(); itr != my->_appenders.end(); ++itr )
           (*itr)->log( m );
 
        if( my->_additivity && my->_parent != nullptr) {
-          my->_parent.log(m);
+          logger parent = my->_parent;
+          g.unlock();
+          parent.log( m );
        }
     }
+
     void logger::set_name( const fc::string& n ) { my->_name = n; }
     const fc::string& logger::name()const { return my->_name; }
 
-    extern bool do_default_config;
-
-    std::unordered_map<std::string,logger>& get_logger_map() {
-      static bool force_link_default_config = fc::do_default_config;
-      //TODO: Atomic compare/swap set
-      static std::unordered_map<std::string,logger>* lm = new std::unordered_map<std::string, logger>();
-      (void)force_link_default_config; // hide warning;
-      return *lm;
+    logger logger::get( const fc::string& s ) {
+       return log_config::get_logger( s );
     }
 
-    logger logger::get( const fc::string& s ) {
-       return get_logger_map()[s];
+    void logger::update( const fc::string& name, logger& log ) {
+       log_config::update_logger( name, log );
     }
 
     logger  logger::get_parent()const { return my->_parent; }
@@ -91,15 +89,8 @@ namespace fc {
     log_level logger::get_log_level()const { return my->_level; }
     logger& logger::set_log_level(log_level ll) { my->_level = ll; return *this; }
 
-    void logger::add_appender( const std::shared_ptr<appender>& a )
-    { my->_appenders.push_back(a); }
-
-//    void logger::remove_appender( const std::shared_ptr<appender>& a )
- //   { my->_appenders.erase(a); }
-
-    std::vector<std::shared_ptr<appender> > logger::get_appenders()const
-    {
-        return my->_appenders;
+    void logger::add_appender( const std::shared_ptr<appender>& a ) {
+       my->_appenders.push_back(a);
     }
 
    bool configure_logging( const logging_config& cfg );

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -10,40 +10,76 @@
 #include <fc/exception/exception.hpp>
 
 namespace fc {
-   extern std::unordered_map<std::string,logger>& get_logger_map();
-   extern std::unordered_map<std::string,appender::ptr>& get_appender_map();
-   logger_config& logger_config::add_appender( const string& s ) { appenders.push_back(s); return *this; }
 
-   void configure_logging( const fc::path& lc )
+   log_config& log_config::get() {
+      static log_config the;
+      return the;
+   }
+
+   bool log_config::register_appender( const fc::string& type, const appender_factory::ptr& f )
    {
+      std::lock_guard g( log_config::get().log_mutex );
+      log_config::get().appender_factory_map[type] = f;
+      return true;
+   }
+
+   logger log_config::get_logger( const fc::string& name ) {
+      std::lock_guard g( log_config::get().log_mutex );
+      return log_config::get().logger_map[name];
+   }
+
+   void log_config::update_logger( const fc::string& name, logger& log ) {
+      std::lock_guard g( log_config::get().log_mutex );
+      if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() )
+         log = log_config::get().logger_map[name];
+   }
+
+   void log_config::initialize_appenders( boost::asio::io_service& ios ) {
+      std::lock_guard g( log_config::get().log_mutex );
+      for( auto& iter : log_config::get().appender_map )
+         iter.second->initialize( ios );
+   }
+
+   void configure_logging( const fc::path& lc ) {
       configure_logging( fc::json::from_file<logging_config>(lc) );
    }
-   bool configure_logging( const logging_config& cfg )
-   {
+   bool configure_logging( const logging_config& cfg ) {
+      return log_config::configure_logging( cfg );
+   }
+
+   bool log_config::configure_logging( const logging_config& cfg ) {
       try {
-      static bool reg_console_appender = appender::register_appender<console_appender>( "console" );
-      static bool reg_gelf_appender = appender::register_appender<gelf_appender>( "gelf" );
-      get_logger_map().clear();
-      get_appender_map().clear();
+      static bool reg_console_appender = log_config::register_appender<console_appender>( "console" );
+      static bool reg_gelf_appender = log_config::register_appender<gelf_appender>( "gelf" );
+
+      std::lock_guard g( log_config::get().log_mutex );
+      log_config::get().logger_map.clear();
+      log_config::get().appender_map.clear();
 
       //slog( "\n%s", fc::json::to_pretty_string(cfg).c_str() );
       for( size_t i = 0; i < cfg.appenders.size(); ++i ) {
-         appender::create( cfg.appenders[i].name, cfg.appenders[i].type, cfg.appenders[i].args );
-        // TODO... process enabled
+         // create appender
+         auto fact_itr = log_config::get().appender_factory_map.find( cfg.appenders[i].type );
+         if( fact_itr == log_config::get().appender_factory_map.end() ) {
+            //wlog( "Unknown appender type '%s'", type.c_str() );
+            continue;
+         }
+         auto ap = fact_itr->second->create( cfg.appenders[i].args );
+         log_config::get().appender_map[cfg.appenders[i].name] = ap;
       }
       for( size_t i = 0; i < cfg.loggers.size(); ++i ) {
-         auto lgr = logger::get( cfg.loggers[i].name );
+         auto lgr = log_config::get().logger_map[cfg.loggers[i].name];
 
          // TODO: finish configure logger here...
          if( cfg.loggers[i].parent.valid() ) {
-            lgr.set_parent( logger::get( *cfg.loggers[i].parent ) );
+            lgr.set_parent( log_config::get().logger_map[*cfg.loggers[i].parent] );
          }
          lgr.set_name(cfg.loggers[i].name);
          if( cfg.loggers[i].level.valid() ) lgr.set_log_level( *cfg.loggers[i].level );
 
 
          for( auto a = cfg.loggers[i].appenders.begin(); a != cfg.loggers[i].appenders.end(); ++a ){
-            auto ap = appender::get( *a );
+            auto ap = log_config::get().appender_map[*a];
             if( ap ) { lgr.add_appender(ap); }
          }
       }


### PR DESCRIPTION
- Enabling feature of updating log config during running process (nodeos) caused SEGFAULT since the logging configuration is not thread safe.
- Add `mutex` around logging configuration and around `logger.log`
- Remove mutexs in `gelf_appender` and `console_appender` since the higher level `mutex` will protect the entire call.
- Moved `appender_factory_map`, `appender_map`, and `logger_map` to a `log_config` class to encapsulate initialization and access.
