### PR TITLE
Revert to log_config dynamic allocation - 1.8.x

### DIFF
--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -12,6 +12,7 @@
 namespace fc {
 
    log_config& log_config::get() {
+      // allocate dynamically which will leak on exit but allow loggers to be used until the very end of execution
       static log_config* the = new log_config;
       return *the;
    }

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -12,8 +12,8 @@
 namespace fc {
 
    log_config& log_config::get() {
-      static log_config the;
-      return the;
+      static log_config* the = new log_config;
+      return *the;
    }
 
    bool log_config::register_appender( const fc::string& type, const appender_factory::ptr& f )


### PR DESCRIPTION
- Revert to leaking loggers on exit to fix shutdown issue