### PR TITLE
Convert optional to null_type variant

### DIFF
--- a/include/fc/reflect/variant.hpp
+++ b/include/fc/reflect/variant.hpp
@@ -29,6 +29,8 @@ namespace fc
          { 
             if( v.valid() )
                vo(name,*v);
+            else
+               vo(name,{});
          }
          template<typename M>
          void add( mutable_variant_object& vo, const char* name, const M& v )const


### PR DESCRIPTION
## Change Description

When given optional is invalid (doesn't contain value), fc::to_variant_visitor doesn't add it to mutable_variant_object. It causes missing key error when comparing `variant_object`s. Instead of omitting key-value, this PR adds null_type variant in the case of invalid optional value.