### PR TITLE
Provide default log level of info for non-configured loggers.

### DIFF
--- a/include/fc/log/logger.hpp
+++ b/include/fc/log/logger.hpp
@@ -3,7 +3,11 @@
 #include <fc/time.hpp>
 #include <fc/log/log_message.hpp>
 
-namespace fc  
+#ifndef DEFAULT_LOGGER
+#define DEFAULT_LOGGER "default"
+#endif
+
+namespace fc
 {
 
    class appender;
@@ -21,7 +25,7 @@ namespace fc
    class logger 
    {
       public:
-         static logger get( const fc::string& name = "default");
+         static logger get( const fc::string& name = DEFAULT_LOGGER );
          static void update( const fc::string& name, logger& log );
 
          logger();
@@ -56,10 +60,6 @@ namespace fc
    };
 
 } // namespace fc
-
-#ifndef DEFAULT_LOGGER
-#define DEFAULT_LOGGER
-#endif
 
 // suppress warning "conditional expression is constant" in the while(0) for visual c++
 // http://cnicholson.net/2009/03/stupid-c-tricks-dowhile0-and-c4127/

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -120,7 +120,7 @@ namespace fc {
                  ) );
 
       logger_config dlc;
-      dlc.name = "default";
+      dlc.name = DEFAULT_LOGGER;
       dlc.level = log_level::info;
       dlc.appenders.push_back("stderr");
       cfg.loggers.push_back( dlc );

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -34,7 +34,7 @@ namespace fc {
       if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() ) {
          log = log_config::get().logger_map[name];
       } else {
-         // no entry for logger, so setup with log_config's registered appenders
+         // no entry for logger, so setup with default logger
          log = log_config::get().logger_map[ DEFAULT_LOGGER ];
          log_config::get().logger_map.emplace( name, log );
       }

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -34,15 +34,9 @@ namespace fc {
       if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() ) {
          log = log_config::get().logger_map[name];
       } else {
-         // no entry for logger, so setup with default logger if it exists, otherwise default construct and use registered appenders
+         // no entry for logger, so setup with default logger if it exists, otherwise do nothing since default logger not configured
          if( log_config::get().logger_map.find( DEFAULT_LOGGER ) != log_config::get().logger_map.end() ) {
             log = log_config::get().logger_map[DEFAULT_LOGGER];
-            log_config::get().logger_map.emplace( name, log );
-         } else {
-            log = logger(name);
-            for( const auto& a : log_config::get().appender_map ) {
-               log.add_appender( a.second );
-            }
             log_config::get().logger_map.emplace( name, log );
          }
       }

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -34,9 +34,17 @@ namespace fc {
       if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() ) {
          log = log_config::get().logger_map[name];
       } else {
-         // no entry for logger, so setup with default logger
-         log = log_config::get().logger_map[ DEFAULT_LOGGER ];
-         log_config::get().logger_map.emplace( name, log );
+         // no entry for logger, so setup with default logger if it exists, otherwise default construct and use registered appenders
+         if( log_config::get().logger_map.find( DEFAULT_LOGGER ) != log_config::get().logger_map.end() ) {
+            log = log_config::get().logger_map[DEFAULT_LOGGER];
+            log_config::get().logger_map.emplace( name, log );
+         } else {
+            log = logger(name);
+            for( const auto& a : log_config::get().appender_map ) {
+               log.add_appender( a.second );
+            }
+            log_config::get().logger_map.emplace( name, log );
+         }
       }
    }
 

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -31,8 +31,16 @@ namespace fc {
 
    void log_config::update_logger( const fc::string& name, logger& log ) {
       std::lock_guard g( log_config::get().log_mutex );
-      if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() )
+      if( log_config::get().logger_map.find( name ) != log_config::get().logger_map.end() ) {
          log = log_config::get().logger_map[name];
+      } else {
+         // no entry for logger, so setup with log_config's registered appenders
+         log = logger(name);
+         for( auto a : log_config::get().appender_map ) {
+            log.add_appender( a.second );
+         }
+         log_config::get().logger_map.emplace( name, log );
+      }
    }
 
    void log_config::initialize_appenders( boost::asio::io_service& ios ) {

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -35,10 +35,7 @@ namespace fc {
          log = log_config::get().logger_map[name];
       } else {
          // no entry for logger, so setup with log_config's registered appenders
-         log = logger(name);
-         for( const auto& a : log_config::get().appender_map ) {
-            log.add_appender( a.second );
-         }
+         log = log_config::get().logger_map[ DEFAULT_LOGGER ];
          log_config::get().logger_map.emplace( name, log );
       }
    }

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -36,7 +36,7 @@ namespace fc {
       } else {
          // no entry for logger, so setup with log_config's registered appenders
          log = logger(name);
-         for( auto a : log_config::get().appender_map ) {
+         for( const auto& a : log_config::get().appender_map ) {
             log.add_appender( a.second );
          }
          log_config::get().logger_map.emplace( name, log );


### PR DESCRIPTION
- Modify `logger_config::update_logger` to setup a logger with the default logger if no `logging.json` is provided.
- This will make non-default loggers have a default log level of the default logger, currently that is `info`.
