### PR TITLE
Remove incorrect move assignment operator from scoped_exit

### DIFF
--- a/include/fc/scoped_exit.hpp
+++ b/include/fc/scoped_exit.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 namespace fc {
 
    template<typename Callback>

--- a/include/fc/scoped_exit.hpp
+++ b/include/fc/scoped_exit.hpp
@@ -22,17 +22,6 @@ namespace fc {
                try { callback(); } catch( ... ) {}
          }
 
-         scoped_exit& operator = ( scoped_exit&& mv ) {
-            if( this != &mv ) {
-               ~scoped_exit();
-               callback = std::move(mv.callback);
-               canceled = mv.canceled;
-               mv.canceled = true;
-            }
-
-            return *this;
-         }
-
          void cancel() { canceled = true; }
 
       private:

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory( crypto )
 add_subdirectory( io )
+add_subdirectory( scoped_exit )
 add_subdirectory( static_variant )
 add_subdirectory( variant )
 

--- a/test/scoped_exit/CMakeLists.txt
+++ b/test/scoped_exit/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable( test_scoped_exit test_scoped_exit.cpp )
+target_link_libraries( test_scoped_exit fc )
+
+add_test(NAME test_scope_exit COMMAND libraries/fc/test/variant/test_scoped_exit WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/scoped_exit/test_scoped_exit.cpp
+++ b/test/scoped_exit/test_scoped_exit.cpp
@@ -1,0 +1,56 @@
+#include <fc/scoped_exit.hpp>
+
+#define BOOST_TEST_MODULE scoped_exit
+#include <boost/test/included/unit_test.hpp>
+
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(scoped_exit_test_suite)
+
+BOOST_AUTO_TEST_CASE(scoped_exit_test)
+{
+   bool result = false;
+   {
+      auto g1 = make_scoped_exit([&]{ result = true; });
+      BOOST_TEST(result == false);
+   }
+   BOOST_TEST(result == true);
+}
+
+BOOST_AUTO_TEST_CASE(cancel) {
+   bool result = false;
+   {
+      auto g1 = make_scoped_exit([&]{ result = true; });
+      BOOST_TEST(result == false);
+      g1.cancel();
+   }
+   BOOST_TEST(result == false);
+}
+
+BOOST_AUTO_TEST_CASE(test_move) {
+   bool result = false;
+   {
+      auto g1 = make_scoped_exit([&]{ result = true; });
+      BOOST_TEST(result == false);
+      {
+         auto g2 = std::move(g1);
+         BOOST_TEST(result == false);
+      }
+      BOOST_TEST(result == true);
+      result = false;
+   }
+   BOOST_TEST(result == false);
+}
+
+struct move_only {
+   move_only() = default;
+   move_only(move_only&&) = default;
+   void operator()() {}
+};
+
+BOOST_AUTO_TEST_CASE(test_forward) {
+   auto g = make_scoped_exit(move_only{});
+   auto g2 = std::move(g);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
There are two problems with it:
- ~scoped_exit() is intended to call the destructor, but it
  is actually parsed as a complement operator + default constructor.
- An explicit destructor call ends the lifetime of the object,
  which makes further use of it undefined behavior.

This function is definitely unused, because it doesn't compile.
