### PR TITLE
Add supprt for boost deque

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -535,11 +535,8 @@ namespace fc {
     inline void pack( Stream& s, const std::deque<T>& value ) {
       FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
       fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::pack( s, *itr );
-        ++itr;
+      for( const auto& i : value ) {
+         fc::raw::pack( s, i );
       }
     }
 
@@ -548,11 +545,8 @@ namespace fc {
       unsigned_int size; fc::raw::unpack( s, size );
       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
       value.resize(size.value);
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::unpack( s, *itr );
-        ++itr;
+      for( auto& i : value ) {
+         fc::raw::unpack( s, i );
       }
     }
 
@@ -560,11 +554,8 @@ namespace fc {
     inline void pack( Stream& s, const boost::container::deque<T, U...>& value ) {
        FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
        fc::raw::pack( s, unsigned_int( (uint32_t) value.size() ) );
-       auto itr = value.begin();
-       auto end = value.end();
-       while( itr != end ) {
-         fc::raw::pack( s, *itr );
-         ++itr;
+       for( const auto& i : value ) {
+          fc::raw::pack( s, i );
        }
     }
 
@@ -574,11 +565,8 @@ namespace fc {
        fc::raw::unpack( s, size );
        FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
        value.resize( size.value );
-       auto itr = value.begin();
-       auto end = value.end();
-       while( itr != end ) {
-         fc::raw::unpack( s, *itr );
-         ++itr;
+       for( auto& i : value ) {
+          fc::raw::unpack( s, i );
        }
     }
 
@@ -586,11 +574,8 @@ namespace fc {
     inline void pack( Stream& s, const std::vector<T>& value ) {
       FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
       fc::raw::pack( s, unsigned_int((uint32_t)value.size()) );
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::pack( s, *itr );
-        ++itr;
+      for( const auto& i : value ) {
+         fc::raw::pack( s, i );
       }
     }
 
@@ -599,11 +584,8 @@ namespace fc {
       unsigned_int size; fc::raw::unpack( s, size );
       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
       value.resize(size.value);
-      auto itr = value.begin();
-      auto end = value.end();
-      while( itr != end ) {
-        fc::raw::unpack( s, *itr );
-        ++itr;
+      for( auto& i : value ) {
+         fc::raw::unpack( s, i );
       }
     }
 

--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -556,6 +556,32 @@ namespace fc {
       }
     }
 
+    template<typename Stream, typename T, typename... U>
+    inline void pack( Stream& s, const boost::container::deque<T, U...>& value ) {
+       FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );
+       fc::raw::pack( s, unsigned_int( (uint32_t) value.size() ) );
+       auto itr = value.begin();
+       auto end = value.end();
+       while( itr != end ) {
+         fc::raw::pack( s, *itr );
+         ++itr;
+       }
+    }
+
+    template<typename Stream, typename T, typename... U>
+    inline void unpack( Stream& s, boost::container::deque<T, U...>& value ) {
+       unsigned_int size;
+       fc::raw::unpack( s, size );
+       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
+       value.resize( size.value );
+       auto itr = value.begin();
+       auto end = value.end();
+       while( itr != end ) {
+         fc::raw::unpack( s, *itr );
+         ++itr;
+       }
+    }
+
     template<typename Stream, typename T>
     inline void pack( Stream& s, const std::vector<T>& value ) {
       FC_ASSERT( value.size() <= MAX_NUM_ARRAY_ELEMENTS );

--- a/include/fc/io/raw_fwd.hpp
+++ b/include/fc/io/raw_fwd.hpp
@@ -53,6 +53,11 @@ namespace fc {
     template<typename Stream, typename T> inline void pack( Stream& s, const std::deque<T>& value );
     template<typename Stream, typename T> inline void unpack( Stream& s, std::deque<T>& value );
 
+    template<typename Stream, typename T, typename... U>
+    inline void pack( Stream& s, const boost::container::deque<T, U...>& value );
+    template<typename Stream, typename T, typename... U>
+    inline void unpack( Stream& s, boost::container::deque<T, U...>& value );
+
     template<typename Stream, typename K, typename V> inline void pack( Stream& s, const std::unordered_map<K,V>& value );
     template<typename Stream, typename K, typename V> inline void unpack( Stream& s, std::unordered_map<K,V>& value );
 

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -136,6 +136,11 @@ namespace fc
    template<typename T>
    void from_variant( const variant& var,  std::deque<T>& vo );
 
+   template<typename T, typename... U>
+   void to_variant( const boost::container::deque<T, U...>& d, fc::variant& vo );
+   template<typename T, typename... U>
+   void from_variant( const fc::variant& v, boost::container::deque<T, U...>& d );
+
    template<typename T>
    void to_variant( const std::set<T>& var,  variant& vo );
    template<typename T>
@@ -518,6 +523,30 @@ namespace fc
       v = std::move(vars);
    }
 
+   /** @ingroup Serializable */
+   template<typename T, typename... U>
+   void from_variant( const variant& v, boost::container::deque<T, U...>& d )
+   {
+      const variants& vars = v.get_array();
+      if( vars.size() > MAX_NUM_ARRAY_ELEMENTS ) throw std::range_error( "too large" );
+      d.clear();
+      d.resize( vars.size() );
+      for( uint32_t i = 0; i < vars.size(); ++i ) {
+         from_variant( vars[i], d[i] );
+      }
+   }
+
+   /** @ingroup Serializable */
+   template<typename T, typename... U>
+   void to_variant( const boost::container::deque<T, U...>& d, fc::variant& vo )
+   {
+      if( d.size() > MAX_NUM_ARRAY_ELEMENTS ) throw std::range_error( "too large" );
+      variants vars(d.size());
+      for( size_t i = 0; i < d.size(); ++i ) {
+         vars[i] = variant( d[i] );
+      }
+      vo = std::move( vars );
+   }
 
    /** @ingroup Serializable */
    template<typename T>


### PR DESCRIPTION
Add support for `boost::container::deque` to `pack/unpack/to_variant/from_variant`.