### PR TITLE
json::to_string deadline - 1.8

### DIFF
--- a/include/fc/exception/exception.hpp
+++ b/include/fc/exception/exception.hpp
@@ -58,6 +58,8 @@ namespace fc
    class exception
    {
       public:
+         static constexpr fc::microseconds format_time_limit = fc::milliseconds( 10 ); // limit time spent formatting exceptions
+
          enum code_enum
          {
             code_value = unspecified_exception_code

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <fc/variant.hpp>
 #include <fc/filesystem.hpp>
+#include <fc/time.hpp>
 
 #define DEFAULT_MAX_RECURSION_DEPTH 200
 
@@ -29,15 +30,15 @@ namespace fc
             legacy_generator = 1
          };
 
-         static ostream& to_stream( ostream& out, const fc::string&);
-         static ostream& to_stream( ostream& out, const variant& v, output_formatting format = stringify_large_ints_and_doubles );
-         static ostream& to_stream( ostream& out, const variants& v, output_formatting format = stringify_large_ints_and_doubles );
-         static ostream& to_stream( ostream& out, const variant_object& v, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline );
+         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
 
          static variant  from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
          static variants variants_from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
-         static string   to_string( const variant& v, output_formatting format = stringify_large_ints_and_doubles );
-         static string   to_pretty_string( const variant& v, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
 
          static bool     is_valid( const std::string& json_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
 
@@ -57,15 +58,15 @@ namespace fc
          }
 
          template<typename T>
-         static string   to_string( const T& v, output_formatting format = stringify_large_ints_and_doubles )
+         static string   to_string( const T& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles )
          {
-            return to_string( variant(v), format );
+            return to_string( variant(v), deadline, format );
          }
 
          template<typename T>
-         static string   to_pretty_string( const T& v, output_formatting format = stringify_large_ints_and_doubles )
+         static string   to_pretty_string( const T& v, const fc::time_point& deadline = fc::time_point::maximum(), output_formatting format = stringify_large_ints_and_doubles )
          {
-            return to_pretty_string( variant(v), format );
+            return to_pretty_string( variant(v), deadline, format );
          }
 
          template<typename T>

--- a/include/fc/io/raw_variant.hpp
+++ b/include/fc/io/raw_variant.hpp
@@ -40,6 +40,10 @@ namespace fc { namespace raw {
          {
             fc::raw::pack( s, v );
          }
+         virtual void handle( const blob& v)const
+         {
+            fc::raw::pack( s, v );
+         }
         
          Stream& s;
         
@@ -109,6 +113,12 @@ namespace fc { namespace raw {
             raw::unpack(s,val);
             v = fc::move(val);
             return;
+         }
+         case variant::blob_type:
+         {
+            blob val;
+            raw::unpack(s,val);
+            v = fc::move(val);
          }
          default:
             FC_THROW_EXCEPTION( parse_error_exception, "Unknown Variant Type ${t}", ("t", t) );

--- a/include/fc/time.hpp
+++ b/include/fc/time.hpp
@@ -11,31 +11,30 @@
 namespace fc {
   class microseconds {
     public:
-        explicit microseconds( int64_t c = 0) :_count(c){}
-        static microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
-        friend microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
-        friend microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
+        constexpr explicit microseconds( int64_t c = 0) :_count(c){}
+        static constexpr microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
+        friend constexpr microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
+        friend constexpr microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
 
-
-        bool operator==(const microseconds& c)const { return _count == c._count; }
-        bool operator!=(const microseconds& c)const { return _count != c._count; }
-        friend bool operator>(const microseconds& a, const microseconds& b){ return a._count > b._count; }
-        friend bool operator>=(const microseconds& a, const microseconds& b){ return a._count >= b._count; }
-        friend bool operator<(const microseconds& a, const microseconds& b){ return a._count < b._count; }
-        friend bool operator<=(const microseconds& a, const microseconds& b){ return a._count <= b._count; }
-        microseconds& operator+=(const microseconds& c) { _count += c._count; return *this; }
-        microseconds& operator-=(const microseconds& c) { _count -= c._count; return *this; }
-        int64_t count()const { return _count; }
-        int64_t to_seconds()const { return _count/1000000; }
+        constexpr bool operator==(const microseconds& c)const { return _count == c._count; }
+        constexpr bool operator!=(const microseconds& c)const { return _count != c._count; }
+        friend constexpr bool operator>(const microseconds& a, const microseconds& b){ return a._count > b._count; }
+        friend constexpr bool operator>=(const microseconds& a, const microseconds& b){ return a._count >= b._count; }
+        constexpr friend bool operator<(const microseconds& a, const microseconds& b){ return a._count < b._count; }
+        constexpr friend bool operator<=(const microseconds& a, const microseconds& b){ return a._count <= b._count; }
+        constexpr microseconds& operator+=(const microseconds& c) { _count += c._count; return *this; }
+        constexpr microseconds& operator-=(const microseconds& c) { _count -= c._count; return *this; }
+        constexpr int64_t count()const { return _count; }
+        constexpr int64_t to_seconds()const { return _count/1000000; }
     private:
         friend class time_point;
         int64_t      _count;
   };
-  inline microseconds seconds( int64_t s ) { return microseconds( s * 1000000 ); }
-  inline microseconds milliseconds( int64_t s ) { return microseconds( s * 1000 ); }
-  inline microseconds minutes(int64_t m) { return seconds(60*m); }
-  inline microseconds hours(int64_t h) { return minutes(60*h); }
-  inline microseconds days(int64_t d) { return hours(24*d); }
+  inline constexpr microseconds seconds( int64_t s ) { return microseconds( s * 1000000 ); }
+  inline constexpr microseconds milliseconds( int64_t s ) { return microseconds( s * 1000 ); }
+  inline constexpr microseconds minutes(int64_t m) { return seconds(60*m); }
+  inline constexpr microseconds hours(int64_t h) { return minutes(60*h); }
+  inline constexpr microseconds days(int64_t d) { return hours(24*d); }
 
   class variant;
   void to_variant( const fc::microseconds&,  fc::variant&  );
@@ -43,27 +42,27 @@ namespace fc {
 
   class time_point {
     public:
-        explicit time_point( microseconds e = microseconds() ) :elapsed(e){}
+        constexpr explicit time_point( microseconds e = microseconds() ) :elapsed(e){}
         static time_point now();
-        static time_point maximum() { return time_point( microseconds::maximum() ); }
-        static time_point min() { return time_point();                      }
+        static constexpr time_point maximum() { return time_point( microseconds::maximum() ); }
+        static constexpr time_point min() { return time_point();                      }
 
         operator fc::string()const;
         static time_point from_iso_string( const fc::string& s );
 
-        const microseconds& time_since_epoch()const { return elapsed; }
-        uint32_t            sec_since_epoch()const  { return elapsed.count() / 1000000; }
-        bool   operator > ( const time_point& t )const                              { return elapsed._count > t.elapsed._count; }
-        bool   operator >=( const time_point& t )const                              { return elapsed._count >=t.elapsed._count; }
-        bool   operator < ( const time_point& t )const                              { return elapsed._count < t.elapsed._count; }
-        bool   operator <=( const time_point& t )const                              { return elapsed._count <=t.elapsed._count; }
-        bool   operator ==( const time_point& t )const                              { return elapsed._count ==t.elapsed._count; }
-        bool   operator !=( const time_point& t )const                              { return elapsed._count !=t.elapsed._count; }
-        time_point&  operator += ( const microseconds& m)                           { elapsed+=m; return *this;                 }
-        time_point&  operator -= ( const microseconds& m)                           { elapsed-=m; return *this;                 }
-        time_point   operator + (const microseconds& m) const { return time_point(elapsed+m); }
-        time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
-        microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
+        constexpr const microseconds& time_since_epoch()const { return elapsed; }
+        constexpr uint32_t            sec_since_epoch()const  { return elapsed.count() / 1000000; }
+        constexpr bool   operator > ( const time_point& t )const                              { return elapsed._count > t.elapsed._count; }
+        constexpr bool   operator >=( const time_point& t )const                              { return elapsed._count >=t.elapsed._count; }
+        constexpr bool   operator < ( const time_point& t )const                              { return elapsed._count < t.elapsed._count; }
+        constexpr bool   operator <=( const time_point& t )const                              { return elapsed._count <=t.elapsed._count; }
+        constexpr bool   operator ==( const time_point& t )const                              { return elapsed._count ==t.elapsed._count; }
+        constexpr bool   operator !=( const time_point& t )const                              { return elapsed._count !=t.elapsed._count; }
+        constexpr time_point&  operator += ( const microseconds& m)                           { elapsed+=m; return *this;                 }
+        constexpr time_point&  operator -= ( const microseconds& m)                           { elapsed-=m; return *this;                 }
+        constexpr time_point   operator + (const microseconds& m) const { return time_point(elapsed+m); }
+        constexpr time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
+       constexpr microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
     private:
         microseconds elapsed;
   };
@@ -74,43 +73,43 @@ namespace fc {
   class time_point_sec
   {
     public:
-        time_point_sec()
+        constexpr time_point_sec()
         :utc_seconds(0){}
 
-        explicit time_point_sec(uint32_t seconds )
+        constexpr explicit time_point_sec(uint32_t seconds )
         :utc_seconds(seconds){}
 
-        time_point_sec( const time_point& t )
+        constexpr time_point_sec( const time_point& t )
         :utc_seconds( t.time_since_epoch().count() / 1000000ll ){}
 
-        static time_point_sec maximum() { return time_point_sec(0xffffffff); }
-        static time_point_sec min() { return time_point_sec(0); }
+        static constexpr time_point_sec maximum() { return time_point_sec(0xffffffff); }
+        static constexpr time_point_sec min() { return time_point_sec(0); }
 
-        operator time_point()const { return time_point( fc::seconds( utc_seconds) ); }
-        uint32_t sec_since_epoch()const { return utc_seconds; }
+        constexpr operator time_point()const { return time_point( fc::seconds( utc_seconds) ); }
+        constexpr uint32_t sec_since_epoch()const { return utc_seconds; }
 
-        time_point_sec operator = ( const fc::time_point& t )
+        constexpr time_point_sec operator = ( const fc::time_point& t )
         {
           utc_seconds = t.time_since_epoch().count() / 1000000ll;
           return *this;
         }
-        friend bool      operator < ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds < b.utc_seconds; }
-        friend bool      operator > ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds > b.utc_seconds; }
-        friend bool      operator <= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds <= b.utc_seconds; }
-        friend bool      operator >= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds >= b.utc_seconds; }
-        friend bool      operator == ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds == b.utc_seconds; }
-        friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
-        time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
-        time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
-        time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
-        time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
-        time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
-        time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
+        constexpr friend bool      operator < ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds < b.utc_seconds; }
+        constexpr friend bool      operator > ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds > b.utc_seconds; }
+        constexpr friend bool      operator <= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds <= b.utc_seconds; }
+        constexpr friend bool      operator >= ( const time_point_sec& a, const time_point_sec& b )  { return a.utc_seconds >= b.utc_seconds; }
+        constexpr friend bool      operator == ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds == b.utc_seconds; }
+        constexpr friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
+        constexpr time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
+        constexpr time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
+        constexpr time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
+        constexpr time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
+        constexpr time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
+        constexpr time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
 
-        friend time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point(t) + m;             }
-        friend time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point(t) - m;             }
-        friend microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
-        friend microseconds operator - ( const time_point& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
+        friend constexpr time_point   operator + ( const time_point_sec& t, const microseconds& m )   { return time_point(t) + m;             }
+        friend constexpr time_point   operator - ( const time_point_sec& t, const microseconds& m )   { return time_point(t) - m;             }
+        friend constexpr microseconds operator - ( const time_point_sec& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
+        friend constexpr microseconds operator - ( const time_point& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
 
         fc::string to_non_delimited_iso_string()const;
         fc::string to_iso_string()const;

--- a/include/fc/time.hpp
+++ b/include/fc/time.hpp
@@ -142,9 +142,12 @@ FC_REFLECT_TYPENAME( fc::time_point_sec )
 
 #define FC_CHECK_DEADLINE( DEADLINE, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
-    if( DEADLINE < fc::time_point::maximum() && DEADLINE < fc::time_point::now() ) \
-       throw timeout_exception( FC_LOG_MESSAGE( error, "deadline ${d} exceeded by ${t}us ", \
-             FC_FORMAT_ARG_PARAMS(__VA_ARGS__)("d", DEADLINE)("t", fc::time_point::now() - DEADLINE) ) ); \
+    if( DEADLINE < fc::time_point::maximum() && DEADLINE < fc::time_point::now() ) { \
+       auto log_mgs = FC_LOG_MESSAGE( error, "deadline ${d} exceeded by ${t}us ", \
+             FC_FORMAT_ARG_PARAMS(__VA_ARGS__)("d", DEADLINE)("t", fc::time_point::now() - DEADLINE) ); \
+       auto msg = log_mgs.get_limited_message(); \
+       throw timeout_exception( std::move( log_mgs ), timeout_exception_code, "timeout_exception", std::move( msg ) ); \
+    } \
   FC_MULTILINE_MACRO_END
 
 #ifdef _MSC_VER

--- a/include/fc/time.hpp
+++ b/include/fc/time.hpp
@@ -140,6 +140,13 @@ FC_REFLECT_TYPENAME( fc::time_point )
 FC_REFLECT_TYPENAME( fc::microseconds )
 FC_REFLECT_TYPENAME( fc::time_point_sec )
 
+#define FC_CHECK_DEADLINE( DEADLINE, ... ) \
+  FC_MULTILINE_MACRO_BEGIN \
+    if( DEADLINE < fc::time_point::maximum() && DEADLINE < fc::time_point::now() ) \
+       throw timeout_exception( FC_LOG_MESSAGE( error, "deadline ${d} exceeded by ${t}us ", \
+             FC_FORMAT_ARG_PARAMS(__VA_ARGS__)("d", DEADLINE)("t", fc::time_point::now() - DEADLINE) ) ); \
+  FC_MULTILINE_MACRO_END
+
 #ifdef _MSC_VER
   #pragma warning (pop)
 #endif /// #ifdef _MSC_VER

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -248,6 +248,7 @@ namespace fc
               virtual void handle( const string& v )const        = 0;
               virtual void handle( const variant_object& v)const = 0;
               virtual void handle( const variants& v)const       = 0;
+              virtual void handle( const blob& v)const           = 0;
         };
 
         void  visit( const visitor& v )const;

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -157,6 +157,7 @@ namespace fc
     */
    string exception::to_detail_string( log_level ll  )const
    {
+      const auto deadline = fc::time_point::now() + fc::milliseconds(10);
       std::stringstream ss;
       try {
          try {
@@ -170,11 +171,14 @@ namespace fc
          for( auto itr = my->_elog.begin(); itr != my->_elog.end(); ) {
             try {
                ss << itr->get_message() << "\n"; //fc::format_string( itr->get_format(), itr->get_data() ) <<"\n";
-               ss << "    " << json::to_string( itr->get_data()) << "\n";
+               ss << "    " << json::to_string( itr->get_data(), deadline ) << "\n";
                ss << "    " << itr->get_context().to_string();
                ++itr;
             } catch( std::bad_alloc& ) {
                throw;
+            } catch( const fc::timeout_exception& e) {
+               ss << "<- timeout exception in to_detail_string: " << e.to_string();
+               break;
             } catch( ... ) {
                ss << "<- exception in to_detail_string.";
             }
@@ -193,6 +197,7 @@ namespace fc
     */
    string exception::to_string( log_level ll   )const
    {
+      const auto deadline = fc::time_point::now() + fc::milliseconds(10);
       std::stringstream ss;
       try {
          ss << my->_what;
@@ -205,10 +210,14 @@ namespace fc
          }
          for( auto itr = my->_elog.begin(); itr != my->_elog.end(); ++itr ) {
             try {
-               ss << fc::format_string( itr->get_format(), itr->get_data()) << "\n";
+               FC_CHECK_DEADLINE(deadline);
+               ss << fc::format_string( itr->get_format(), itr->get_data(), true) << "\n";
                //      ss << "    " << itr->get_context().to_string() <<"\n";
             } catch( std::bad_alloc& ) {
                throw;
+            } catch( const fc::timeout_exception& e) {
+               ss << "<- timeout exception in to_string: " << e.to_detail_string();
+               break;
             } catch( ... ) {
                ss << "<- exception in to_string.\n";
             }

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -177,7 +177,7 @@ namespace fc
             } catch( std::bad_alloc& ) {
                throw;
             } catch( const fc::timeout_exception& e) {
-               ss << "<- timeout exception in to_detail_string: " << e.to_string();
+               ss << "<- timeout exception in to_detail_string: " << e.what();
                break;
             } catch( ... ) {
                ss << "<- exception in to_detail_string.";
@@ -216,7 +216,7 @@ namespace fc
             } catch( std::bad_alloc& ) {
                throw;
             } catch( const fc::timeout_exception& e) {
-               ss << "<- timeout exception in to_string: " << e.to_detail_string();
+               ss << "<- timeout exception in to_string: " << e.what();
                break;
             } catch( ... ) {
                ss << "<- exception in to_string.\n";

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -157,7 +157,7 @@ namespace fc
     */
    string exception::to_detail_string( log_level ll  )const
    {
-      const auto deadline = fc::time_point::now() + fc::milliseconds(10);
+      const auto deadline = fc::time_point::now() + format_time_limit;
       std::stringstream ss;
       try {
          try {
@@ -197,7 +197,7 @@ namespace fc
     */
    string exception::to_string( log_level ll   )const
    {
-      const auto deadline = fc::time_point::now() + fc::milliseconds(10);
+      const auto deadline = fc::time_point::now() + format_time_limit;
       std::stringstream ss;
       try {
          ss << my->_what;

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -568,25 +568,6 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format )
-   {
-      FC_CHECK_DEADLINE(deadline);
-      os << '{';
-       auto itr = o.begin();
-
-       while( itr != o.end() )
-       {
-          escape_string( itr->key(), os, deadline );
-          os << ':';
-          to_stream( os, itr->value(), deadline, format );
-          ++itr;
-          if( itr != o.end() )
-             os << ',';
-       }
-       os << '}';
-   }
-
-   template<typename T>
    void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format )
    {
       FC_CHECK_DEADLINE(deadline);
@@ -601,6 +582,25 @@ namespace fc
             os << ',';
       }
       os << ']';
+   }
+
+   template<typename T>
+   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format )
+   {
+       FC_CHECK_DEADLINE(deadline);
+       os << '{';
+       auto itr = o.begin();
+
+       while( itr != o.end() )
+       {
+          escape_string( itr->key(), os, deadline );
+          os << ':';
+          to_stream( os, itr->value(), deadline, format );
+          ++itr;
+          if( itr != o.end() )
+             os << ',';
+       }
+       os << '}';
    }
 
    template<typename T>

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -22,10 +22,9 @@ namespace fc
     template<typename T, json::parse_type parser_type> variants arrayFromStream( T& in, uint32_t max_depth );
     template<typename T, json::parse_type parser_type> variant number_from_stream( T& in );
     template<typename T> variant token_from_stream( T& in );
-    void escape_string( const std::string& str, std::ostream& os );
-    template<typename T> void to_stream( T& os, const variants& a, json::output_formatting format );
-    template<typename T> void to_stream( T& os, const variant_object& o, json::output_formatting format );
-    template<typename T> void to_stream( T& os, const variant& v, json::output_formatting format );
+    template<typename T> void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format );
+    template<typename T> void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format );
+    template<typename T> void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format );
     std::string pretty_print( const std::string& v, uint8_t indent );
 }
 
@@ -491,11 +490,13 @@ namespace fc
     *
     *  All other characters are printed as UTF8.
     */
-   void escape_string( const string& str, std::ostream& os )
+   void escape_string( const string& str, std::ostream& os, const fc::time_point& deadline )
    {
       os << '"';
-      for( auto itr = str.begin(); itr != str.end(); ++itr )
+      size_t i = 0;
+      for( auto itr = str.begin(); itr != str.end(); ++i,++itr )
       {
+         if( i % 1024 == 0 ) FC_CHECK_DEADLINE(deadline);
          switch( *itr )
          {
             case '\b':        // \x08
@@ -560,38 +561,24 @@ namespace fc
       }
       os << '"';
    }
-   std::ostream& json::to_stream( std::ostream& out, const std::string& str )
+   std::ostream& json::to_stream( std::ostream& out, const std::string& str, const fc::time_point& deadline )
    {
-        escape_string( str, out );
+        escape_string( str, out, deadline );
         return out;
    }
 
    template<typename T>
-   void to_stream( T& os, const variants& a, json::output_formatting format )
+   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format )
    {
-      os << '[';
-      auto itr = a.begin();
-
-      while( itr != a.end() )
-      {
-         to_stream( os, *itr, format );
-         ++itr;
-         if( itr != a.end() )
-            os << ',';
-      }
-      os << ']';
-   }
-   template<typename T>
-   void to_stream( T& os, const variant_object& o, json::output_formatting format )
-   {
-       os << '{';
+      FC_CHECK_DEADLINE(deadline);
+      os << '{';
        auto itr = o.begin();
 
        while( itr != o.end() )
        {
-          escape_string( itr->key(), os );
+          escape_string( itr->key(), os, deadline );
           os << ':';
-          to_stream( os, itr->value(), format );
+          to_stream( os, itr->value(), deadline, format );
           ++itr;
           if( itr != o.end() )
              os << ',';
@@ -600,8 +587,26 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant& v, json::output_formatting format )
+   void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format )
    {
+      FC_CHECK_DEADLINE(deadline);
+      os << '[';
+      auto itr = a.begin();
+
+      while( itr != a.end() )
+      {
+         to_stream( os, *itr, deadline, format );
+         ++itr;
+         if( itr != a.end() )
+            os << ',';
+      }
+      os << ']';
+   }
+
+   template<typename T>
+   void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format )
+   {
+      FC_CHECK_DEADLINE(deadline);
       switch( v.get_type() )
       {
          case variant::null_type:
@@ -639,21 +644,21 @@ namespace fc
               os << v.as_string();
               return;
          case variant::string_type:
-              escape_string( v.get_string(), os );
+              escape_string( v.get_string(), os, deadline );
               return;
          case variant::blob_type:
-              escape_string( v.as_string(), os );
+              escape_string( v.as_string(), os, deadline );
               return;
          case variant::array_type:
            {
               const variants&  a = v.get_array();
-              to_stream( os, a, format );
+              to_stream( os, a, deadline, format );
               return;
            }
          case variant::object_type:
            {
               const variant_object& o =  v.get_object();
-              to_stream(os, o, format );
+              to_stream(os, o, deadline, format );
               return;
            }
          default:
@@ -661,10 +666,11 @@ namespace fc
       }
    }
 
-   std::string   json::to_string( const variant& v, output_formatting format )
+   std::string   json::to_string( const variant& v, const fc::time_point& deadline, output_formatting format )
    {
       std::stringstream ss;
-      fc::to_stream( ss, v, format );
+      fc::to_stream( ss, v, deadline, format );
+      FC_CHECK_DEADLINE(deadline);
       return ss.str();
    }
 
@@ -764,21 +770,23 @@ namespace fc
 
 
 
-   std::string json::to_pretty_string( const variant& v, output_formatting format )
+   std::string json::to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format )
    {
-      return pretty_print(to_string(v, format), 2);
+      auto s = to_string(v, deadline, format);
+      FC_CHECK_DEADLINE(deadline);
+      return pretty_print( std::move( s ), 2);
    }
 
    bool json::save_to_file( const variant& v, const fc::path& fi, bool pretty, output_formatting format )
    {
       if( pretty ) {
-         auto str = json::to_pretty_string( v, format );
+         auto str = json::to_pretty_string( v, fc::time_point::maximum(), format );
          std::ofstream o(fi.generic_string().c_str());
          o.write( str.c_str(), str.size() );
          return o.good();
       } else {
          std::ofstream o(fi.generic_string().c_str());
-         fc::to_stream( o, v, format );
+         fc::to_stream( o, v, fc::time_point::maximum(), format );
          return o.good();
       }
    }
@@ -821,19 +829,22 @@ namespace fc
    }
    */
 
-   std::ostream& json::to_stream( std::ostream& out, const variant& v, output_formatting format )
+   std::ostream& json::to_stream( std::ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format )
    {
-      fc::to_stream( out, v, format );
+      FC_CHECK_DEADLINE(deadline);
+      fc::to_stream( out, v, deadline, format );
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variants& v, output_formatting format )
+   std::ostream& json::to_stream( std::ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format )
    {
-      fc::to_stream( out, v, format );
+      FC_CHECK_DEADLINE(deadline);
+      fc::to_stream( out, v, deadline, format );
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, output_formatting format )
+   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format )
    {
-      fc::to_stream( out, v, format );
+      FC_CHECK_DEADLINE(deadline);
+      fc::to_stream( out, v, deadline, format );
       return out;
    }
 

--- a/src/log/gelf_appender.cpp
+++ b/src/log/gelf_appender.cpp
@@ -108,7 +108,7 @@ namespace fc
     mutable_variant_object gelf_message;
     gelf_message["version"] = "1.1";
     gelf_message["host"] = my->cfg.host;
-    gelf_message["short_message"] = format_string(message.get_format(), message.get_data());
+    gelf_message["short_message"] = format_string(message.get_format(), message.get_data(), true);
 
     // use now() instead of context.get_timestamp() because log_message construction can include user provided long running calls
     const auto time_ns = time_point::now().time_since_epoch().count();
@@ -148,7 +148,7 @@ namespace fc
     if (!context.get_task_name().empty())
       gelf_message["_task_name"] = context.get_task_name();
 
-    string gelf_message_as_string = json::to_string(gelf_message, json::legacy_generator); // GELF 1.1 specifies unstringified numbers
+    string gelf_message_as_string = json::to_string(gelf_message, fc::time_point::now() + fc::milliseconds(10), json::legacy_generator); // GELF 1.1 specifies unstringified numbers
     //unsigned uncompressed_size = gelf_message_as_string.size();
     gelf_message_as_string = zlib_compress(gelf_message_as_string);
 

--- a/src/log/gelf_appender.cpp
+++ b/src/log/gelf_appender.cpp
@@ -148,7 +148,9 @@ namespace fc
     if (!context.get_task_name().empty())
       gelf_message["_task_name"] = context.get_task_name();
 
-    string gelf_message_as_string = json::to_string(gelf_message, fc::time_point::now() + fc::milliseconds(10), json::legacy_generator); // GELF 1.1 specifies unstringified numbers
+    string gelf_message_as_string = json::to_string(gelf_message,
+          fc::time_point::now() + fc::exception::format_time_limit,
+          json::legacy_generator); // GELF 1.1 specifies unstringified numbers
     //unsigned uncompressed_size = gelf_message_as_string.size();
     gelf_message_as_string = zlib_compress(gelf_message_as_string);
 

--- a/src/log/logger.cpp
+++ b/src/log/logger.cpp
@@ -1,6 +1,7 @@
 #include <fc/log/logger.hpp>
 #include <fc/log/log_message.hpp>
 #include <fc/log/appender.hpp>
+#include <fc/exception/exception.hpp>
 #include <fc/filesystem.hpp>
 #include <unordered_map>
 #include <string>
@@ -62,8 +63,17 @@ namespace fc {
        std::unique_lock g( log_config::get().log_mutex );
        m.get_context().append_context( my->_name );
 
-       for( auto itr = my->_appenders.begin(); itr != my->_appenders.end(); ++itr )
-          (*itr)->log( m );
+       for( auto itr = my->_appenders.begin(); itr != my->_appenders.end(); ++itr ) {
+          try {
+             (*itr)->log( m );
+          } catch( fc::exception& er ) {
+             std::cerr << "ERROR: logger::log fc::exception: " << er.to_detail_string() << std::endl;
+          } catch( const std::exception& e ) {
+             std::cerr << "ERROR: logger::log std::exception: " << e.what() << std::endl;
+          } catch( ... ) {
+             std::cerr << "ERROR: logger::log unknown exception: " << std::endl;
+          }
+       }
 
        if( my->_additivity && my->_parent != nullptr) {
           logger parent = my->_parent;

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -337,7 +337,7 @@ public:
       req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
       req.set(http::field::content_type, "application/json");
       req.keep_alive(true);
-      req.body() = json::to_string(payload);
+      req.body() = json::to_string(payload, _deadline);
       req.prepare_payload();
 
       auto conn_iter = get_connection(dest, deadline);

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -292,6 +292,9 @@ void  variant::visit( const visitor& v )const
       case object_type:
          v.handle( **reinterpret_cast<const const_variant_object_ptr*>(this) );
          return;
+      case blob_type:
+         v.handle( **reinterpret_cast<const const_blob_ptr*>(this) );
+         return;
       default:
          FC_THROW_EXCEPTION( assert_exception, "Invalid Type / Corrupted Memory" );
    }

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -804,7 +804,7 @@ string format_string( const string& frmt, const variant_object& args, bool minim
                   if( minimize ) {
                      replaced = false;
                   } else {
-                     result += json::to_string( val->value() );
+                     result += json::to_string( val->value(), fc::time_point::maximum() );
                   }
                } else if( val->value().is_blob() ) {
                   if( minimize && val->value().get_blob().data.size() > minimize_sub_max_size ) {


### PR DESCRIPTION
- Added `deadline` to `json::to_string`
- Added new `FC_CHECK_DEADLINE` macro
- Modified `logger::log` to not throw exceptions
- Added `blob_type` support to variant pack/unpack
- Made `time_point` methods `constexpr`