### PR TITLE
Fix crash when using using a bad appender. - 2.0

### DIFF
--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -87,8 +87,10 @@ namespace fc {
 
 
          for( auto a = cfg.loggers[i].appenders.begin(); a != cfg.loggers[i].appenders.end(); ++a ){
-            auto ap = log_config::get().appender_map[*a];
-            if( ap ) { lgr.add_appender(ap); }
+            auto ap_it = log_config::get().appender_map.find(*a);
+            if( ap_it != log_config::get().appender_map.end() ) {
+               lgr.add_appender(ap_it->second);
+            }
          }
       }
       return reg_console_appender || reg_gelf_appender;


### PR DESCRIPTION
unordered_map::operator[] creates a value inititalized element
if the key isn't present.  This breaks initialize_appenders, which
expects appender_map to contain only non-null pointers.