### PR TITLE
detect pthread_get/setname_np before usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,19 @@ list(APPEND sources ${fc_headers})
 
 setup_library( fc SOURCES ${sources} LIBRARY_TYPE STATIC DONT_INSTALL_LIBRARY )
 
+function(detect_thread_name)
+  include(CheckSymbolExists)
+  list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+  list(APPEND CMAKE_REQUIRED_LIBRARIES "-pthread")
+  check_symbol_exists(pthread_setname_np pthread.h HAVE_PTHREAD_SETNAME_NP)
+  if(HAVE_PTHREAD_SETNAME_NP)
+    set_source_files_properties(src/log/logger_config.cpp PROPERTIES COMPILE_DEFINITIONS FC_USE_PTHREAD_NAME_NP)
+  endif()
+endfunction()
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  detect_thread_name()
+endif()
+
 find_package(Boost 1.66 REQUIRED COMPONENTS
     date_time
     filesystem

--- a/src/log/logger_config.cpp
+++ b/src/log/logger_config.cpp
@@ -133,7 +133,7 @@ namespace fc {
 
    static thread_local std::string thread_name;
    void set_os_thread_name( const string& name ) {
-#ifdef __linux__
+#ifdef FC_USE_PTHREAD_NAME_NP
       pthread_setname_np( pthread_self(), name.c_str() );
 #endif
    }
@@ -142,7 +142,7 @@ namespace fc {
    }
    const string& get_thread_name() {
       if( thread_name.empty() ) {
-#ifdef __linux__
+#ifdef FC_USE_PTHREAD_NAME_NP
          char thr_name[64];
          int rc = pthread_getname_np( pthread_self(), thr_name, 64 );
          if( rc == 0 ) {


### PR DESCRIPTION
musl, a reasonably popular libc on linux, does not have `pthread_setname_np` & `pthread_getname_np`. Detect presence of these functions before using them.