### PR TITLE
Add expansion for data types with minimize flag being set

### DIFF
--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -30,15 +30,15 @@ namespace fc
             stringify_large_ints_and_doubles = 0,
             legacy_generator = 1
          };
-         static constexpr int64_t Max_Length_Limit = -1;
-         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline, const int64_t max_len = Max_Length_Limit );
-         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
-         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
-         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
+         static constexpr uint64_t max_length_limit = std::numeric_limits<uint64_t>::max();
+         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline, const uint64_t max_len = max_length_limit );
+         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
+         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
+         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
 
          static variant  from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
          static variants variants_from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
-         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
+         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
          static string   to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
 
          static bool     is_valid( const std::string& json_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
@@ -75,11 +75,9 @@ namespace fc
          {
             return save_to_file( variant(v), fc::path(p), pretty, format );
          }
-         static void yield(ostream& out, const fc::time_point& deadline, const int64_t max_len) {
+         static void yield(ostream& out, const fc::time_point& deadline, const uint64_t max_len) {
             FC_CHECK_DEADLINE(deadline);
-            if ( (max_len != Max_Length_Limit) && out.tellp() > max_len ) {
-               throw;
-            }
+            FC_ASSERT( out.tellp() <= max_len );
          };
    };
 

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -31,6 +31,7 @@ namespace fc
          };
          using yield_func = std::function<void(std::ostream&)>;
          static constexpr uint64_t max_length_limit = std::numeric_limits<uint64_t>::max();
+         static constexpr size_t escape_string_yeild_check_count = 128;
          static ostream& to_stream( ostream& out, const fc::string&, const yield_func& yield );
          static ostream& to_stream( ostream& out, const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
          static ostream& to_stream( ostream& out, const variants& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
@@ -80,6 +81,7 @@ namespace fc
          }
    };
 
+   void escape_string( const string& str, std::ostream& os, const json::yield_func& yield );
 } // fc
 
 #undef DEFAULT_MAX_RECURSION_DEPTH

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -2,6 +2,7 @@
 #include <fc/variant.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/time.hpp>
+#include <fc/exception/exception.hpp>
 
 #define DEFAULT_MAX_RECURSION_DEPTH 200
 
@@ -29,15 +30,15 @@ namespace fc
             stringify_large_ints_and_doubles = 0,
             legacy_generator = 1
          };
-
-         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline );
-         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
-         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
-         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static constexpr int64_t Max_Length_Limit = -1;
+         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline, const int64_t max_len = Max_Length_Limit );
+         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
+         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
+         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
 
          static variant  from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
          static variants variants_from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
-         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const int64_t max_len = Max_Length_Limit );
          static string   to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
 
          static bool     is_valid( const std::string& json_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
@@ -74,6 +75,12 @@ namespace fc
          {
             return save_to_file( variant(v), fc::path(p), pretty, format );
          }
+         static void yield(ostream& out, const fc::time_point& deadline, const int64_t max_len) {
+            FC_CHECK_DEADLINE(deadline);
+            if ( (max_len != Max_Length_Limit) && out.tellp() > max_len ) {
+               throw;
+            }
+         };
    };
 
 } // fc

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -2,7 +2,6 @@
 #include <fc/variant.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/time.hpp>
-#include <fc/exception/exception.hpp>
 
 #define DEFAULT_MAX_RECURSION_DEPTH 200
 
@@ -30,16 +29,20 @@ namespace fc
             stringify_large_ints_and_doubles = 0,
             legacy_generator = 1
          };
+         using yield_func = std::function<void(std::ostream&)>;
          static constexpr uint64_t max_length_limit = std::numeric_limits<uint64_t>::max();
-         static ostream& to_stream( ostream& out, const fc::string&, const fc::time_point& deadline, const uint64_t max_len = max_length_limit );
-         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
-         static ostream& to_stream( ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
-         static ostream& to_stream( ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
+         static ostream& to_stream( ostream& out, const fc::string&, const yield_func& yield );
+         static ostream& to_stream( ostream& out, const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variants& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variant_object& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+         static ostream& to_stream( ostream& out, const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles );
 
          static variant  from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
          static variants variants_from_string( const string& utf8_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
-         static string   to_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles, const uint64_t max_len = max_length_limit );
-         static string   to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles);
+         static string   to_string( const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles);
+         static string   to_pretty_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles );
+         static string   to_pretty_string( const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
 
          static bool     is_valid( const std::string& json_str, parse_type ptype = legacy_parser, uint32_t max_depth = DEFAULT_MAX_RECURSION_DEPTH );
 
@@ -65,9 +68,9 @@ namespace fc
          }
 
          template<typename T>
-         static string   to_pretty_string( const T& v, const fc::time_point& deadline = fc::time_point::maximum(), output_formatting format = stringify_large_ints_and_doubles )
+         static string   to_pretty_string( const T& v, const fc::time_point& deadline = fc::time_point::maximum(), const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles )
          {
-            return to_pretty_string( variant(v), deadline, format );
+            return to_pretty_string( variant(v), deadline, max_len, format );
          }
 
          template<typename T>
@@ -75,10 +78,6 @@ namespace fc
          {
             return save_to_file( variant(v), fc::path(p), pretty, format );
          }
-         static void yield(ostream& out, const fc::time_point& deadline, const uint64_t max_len) {
-            FC_CHECK_DEADLINE(deadline);
-            FC_ASSERT( out.tellp() <= max_len );
-         };
    };
 
 } // fc

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -21,9 +21,9 @@ namespace fc
     template<typename T, json::parse_type parser_type> variants arrayFromStream( T& in, uint32_t max_depth );
     template<typename T, json::parse_type parser_type> variant number_from_stream( T& in );
     template<typename T> variant token_from_stream( T& in );
-    template<typename T> void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
-    template<typename T> void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
-    template<typename T> void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
+    template<typename T> void to_stream( T& os, const variants& a, const json::yield_func& yield, json::output_formatting format );
+    template<typename T> void to_stream( T& os, const variant_object& o, const json::yield_func& yield, json::output_formatting format );
+    template<typename T> void to_stream( T& os, const variant& v, const json::yield_func& yield, json::output_formatting format );
     std::string pretty_print( const std::string& v, uint8_t indent );
 }
 
@@ -489,14 +489,13 @@ namespace fc
     *
     *  All other characters are printed as UTF8.
     */
-   void escape_string( const string& str, std::ostream& os, const fc::time_point& deadline, const uint64_t max_len )
+   void escape_string( const string& str, std::ostream& os, const json::yield_func& yield )
    {
       os << '"';
       size_t i = 0;
       for( auto itr = str.begin(); itr != str.end(); ++i,++itr )
       {
-         if( i % 1024 == 0 ) FC_CHECK_DEADLINE(deadline);
-         FC_ASSERT( os.tellp() <= max_len );
+         if( i % 128 == 0 ) yield(os);
          switch( *itr )
          {
             case '\b':        // \x08
@@ -561,22 +560,22 @@ namespace fc
       }
       os << '"';
    }
-   std::ostream& json::to_stream( std::ostream& out, const std::string& str, const fc::time_point& deadline, const uint64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const std::string& str, const json::yield_func& yield )
    {
-        escape_string( str, out, deadline, max_len );
+        escape_string( str, out, yield );
         return out;
    }
 
    template<typename T>
-   void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
+   void to_stream( T& os, const variants& a, const json::yield_func& yield, json::output_formatting format )
    {
-      json::yield(os, deadline, max_len);
+      yield(os);
       os << '[';
       auto itr = a.begin();
 
       while( itr != a.end() )
       {
-         to_stream( os, *itr, deadline, format, max_len );
+         to_stream( os, *itr, yield, format );
          ++itr;
          if( itr != a.end() )
             os << ',';
@@ -585,17 +584,17 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
+   void to_stream( T& os, const variant_object& o, const json::yield_func& yield, json::output_formatting format )
    {
-       json::yield(os, deadline, max_len);
+       yield(os);
        os << '{';
        auto itr = o.begin();
 
        while( itr != o.end() )
        {
-          escape_string( itr->key(), os, deadline, max_len );
+          escape_string( itr->key(), os, yield );
           os << ':';
-          to_stream( os, itr->value(), deadline, format, max_len );
+          to_stream( os, itr->value(), yield, format );
           ++itr;
           if( itr != o.end() )
              os << ',';
@@ -604,9 +603,9 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
+   void to_stream( T& os, const variant& v, const json::yield_func& yield, json::output_formatting format )
    {
-      json::yield(os, deadline, max_len);
+      yield(os);
       switch( v.get_type() )
       {
          case variant::null_type:
@@ -644,21 +643,21 @@ namespace fc
               os << v.as_string();
               return;
          case variant::string_type:
-              escape_string( v.get_string(), os, deadline, max_len );
+              escape_string( v.get_string(), os, yield );
               return;
          case variant::blob_type:
-              escape_string( v.as_string(), os, deadline, max_len );
+              escape_string( v.as_string(), os, yield );
               return;
          case variant::array_type:
            {
               const variants&  a = v.get_array();
-              to_stream( os, a, deadline, format, max_len );
+              to_stream( os, a, yield, format );
               return;
            }
          case variant::object_type:
            {
               const variant_object& o =  v.get_object();
-              to_stream(os, o, deadline, format, max_len );
+              to_stream(os, o, yield, format );
               return;
            }
          default:
@@ -666,16 +665,24 @@ namespace fc
       }
    }
 
-   std::string   json::to_string( const variant& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
+   std::string   json::to_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len, output_formatting format )
+   {
+      const auto yield = [&](std::ostream& os) {
+         FC_CHECK_DEADLINE(deadline);
+         FC_ASSERT( os.tellp() <= max_len );
+      };
+      return to_string( v, yield, format );
+   }
+
+   std::string   json::to_string( const variant& v, const json::yield_func& yield, output_formatting format )
    {
       std::stringstream ss;
-      fc::to_stream( ss, v, deadline, format, max_len );
-      FC_CHECK_DEADLINE(deadline);
+      fc::to_stream( ss, v, yield, format );
+      yield(ss);
       return ss.str();
    }
 
-
-    std::string pretty_print( const std::string& v, uint8_t indent ) {
+   std::string pretty_print( const std::string& v, uint8_t indent ) {
       int level = 0;
       std::stringstream ss;
       bool first = false;
@@ -770,23 +777,34 @@ namespace fc
 
 
 
-   std::string json::to_pretty_string( const variant& v, const fc::time_point& deadline, output_formatting format )
-   {
-      auto s = to_string(v, deadline, format);
-      FC_CHECK_DEADLINE(deadline);
+   std::string json::to_pretty_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len, output_formatting format ) {
+      const auto yield = [&](std::ostream& os) {
+         FC_CHECK_DEADLINE(deadline);
+         FC_ASSERT( os.tellp() <= max_len );
+      };
+      return to_pretty_string(v, yield, format);
+   }
+
+   std::string json::to_pretty_string( const variant& v, const json::yield_func& yield, output_formatting format ) {
+
+      auto s = to_string(v, yield, format);
       return pretty_print( std::move( s ), 2);
    }
 
    bool json::save_to_file( const variant& v, const fc::path& fi, bool pretty, output_formatting format )
    {
       if( pretty ) {
-         auto str = json::to_pretty_string( v, fc::time_point::maximum(), format );
+         auto str = json::to_pretty_string( v, fc::time_point::maximum(), max_length_limit, format );
          std::ofstream o(fi.generic_string().c_str());
          o.write( str.c_str(), str.size() );
          return o.good();
       } else {
          std::ofstream o(fi.generic_string().c_str());
-         fc::to_stream( o, v, fc::time_point::maximum(), format );
+         const auto yield = [&](std::ostream& os) {
+            FC_CHECK_DEADLINE(fc::time_point::maximum());
+            FC_ASSERT( os.tellp() <= max_length_limit );
+         };
+         fc::to_stream( o, v, yield, format );
          return o.good();
       }
    }
@@ -829,38 +847,28 @@ namespace fc
    }
    */
 
-   std::ostream& json::to_stream( std::ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variant& v, const json::yield_func& yield, output_formatting format )
    {
-      try {
-         yield(out, deadline, max_len);
-         fc::to_stream( out, v, deadline, format, max_len );
-      } catch (...)
-      {
-         out << "...";
-      }
+      fc::to_stream( out, v, yield, format );
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variants& v, const json::yield_func& yield, output_formatting format )
    {
-      try {
-         yield(out, deadline, max_len);
-         fc::to_stream( out, v, deadline, format, max_len );
-      } catch (...)
-      {
-         out << "...";
-      }
+      fc::to_stream( out, v, yield, format );
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, const json::yield_func& yield, output_formatting format )
    {
-      try {
-         yield(out, deadline, max_len);
-         fc::to_stream( out, v, deadline, format, max_len);
-      } catch (...)
-      {
-         out << "...";
-      }
+      fc::to_stream( out, v, yield, format );
       return out;
+   }
+
+   std::ostream& json::to_stream( std::ostream& out, const variant& v, const fc::time_point& deadline, const uint64_t max_len, output_formatting format ) {
+      const auto yield = [&](std::ostream& os) {
+         FC_CHECK_DEADLINE(deadline);
+         FC_ASSERT( os.tellp() <= max_len );
+      };
+      return to_stream(out, v, yield, format);
    }
 
    bool json::is_valid( const std::string& utf8_str, parse_type ptype, uint32_t max_depth )

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -497,7 +497,7 @@ namespace fc
       for( auto itr = str.begin(); itr != str.end(); ++i,++itr )
       {
          if( i % 1024 == 0 ) FC_CHECK_DEADLINE(deadline);
-         if ( i + init_pos > max_len)  throw;
+         if ( os.tellp() > max_len)  throw;
          switch( *itr )
          {
             case '\b':        // \x08

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -21,9 +21,9 @@ namespace fc
     template<typename T, json::parse_type parser_type> variants arrayFromStream( T& in, uint32_t max_depth );
     template<typename T, json::parse_type parser_type> variant number_from_stream( T& in );
     template<typename T> variant token_from_stream( T& in );
-    template<typename T> void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len = json::Max_Length_Limit );
-    template<typename T> void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len = json::Max_Length_Limit );
-    template<typename T> void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len = json::Max_Length_Limit );
+    template<typename T> void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
+    template<typename T> void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
+    template<typename T> void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len = json::max_length_limit );
     std::string pretty_print( const std::string& v, uint8_t indent );
 }
 
@@ -489,15 +489,14 @@ namespace fc
     *
     *  All other characters are printed as UTF8.
     */
-   void escape_string( const string& str, std::ostream& os, const fc::time_point& deadline, const int64_t max_len )
+   void escape_string( const string& str, std::ostream& os, const fc::time_point& deadline, const uint64_t max_len )
    {
       os << '"';
       size_t i = 0;
-      const auto init_pos = os.tellp();
       for( auto itr = str.begin(); itr != str.end(); ++i,++itr )
       {
          if( i % 1024 == 0 ) FC_CHECK_DEADLINE(deadline);
-         if ( os.tellp() > max_len)  throw;
+         FC_ASSERT( os.tellp() <= max_len );
          switch( *itr )
          {
             case '\b':        // \x08
@@ -562,14 +561,14 @@ namespace fc
       }
       os << '"';
    }
-   std::ostream& json::to_stream( std::ostream& out, const std::string& str, const fc::time_point& deadline, const int64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const std::string& str, const fc::time_point& deadline, const uint64_t max_len )
    {
         escape_string( str, out, deadline, max_len );
         return out;
    }
 
    template<typename T>
-   void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len )
+   void to_stream( T& os, const variants& a, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
    {
       json::yield(os, deadline, max_len);
       os << '[';
@@ -586,7 +585,7 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len )
+   void to_stream( T& os, const variant_object& o, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
    {
        json::yield(os, deadline, max_len);
        os << '{';
@@ -605,7 +604,7 @@ namespace fc
    }
 
    template<typename T>
-   void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const int64_t max_len )
+   void to_stream( T& os, const variant& v, const fc::time_point& deadline, json::output_formatting format, const uint64_t max_len )
    {
       json::yield(os, deadline, max_len);
       switch( v.get_type() )
@@ -667,7 +666,7 @@ namespace fc
       }
    }
 
-   std::string   json::to_string( const variant& v, const fc::time_point& deadline, output_formatting format, const int64_t max_len )
+   std::string   json::to_string( const variant& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
    {
       std::stringstream ss;
       fc::to_stream( ss, v, deadline, format, max_len );
@@ -830,7 +829,7 @@ namespace fc
    }
    */
 
-   std::ostream& json::to_stream( std::ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format, const int64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variant& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
    {
       try {
          yield(out, deadline, max_len);
@@ -841,7 +840,7 @@ namespace fc
       }
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format, const int64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variants& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
    {
       try {
          yield(out, deadline, max_len);
@@ -852,7 +851,7 @@ namespace fc
       }
       return out;
    }
-   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format, const int64_t max_len )
+   std::ostream& json::to_stream( std::ostream& out, const variant_object& v, const fc::time_point& deadline, output_formatting format, const uint64_t max_len )
    {
       try {
          yield(out, deadline, max_len);

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -801,8 +801,7 @@ namespace fc
       } else {
          std::ofstream o(fi.generic_string().c_str());
          const auto yield = [&](std::ostream& os) {
-            FC_CHECK_DEADLINE(fc::time_point::maximum());
-            FC_ASSERT( os.tellp() <= max_length_limit );
+            // no limitation
          };
          fc::to_stream( o, v, yield, format );
          return o.good();

--- a/src/io/json.cpp
+++ b/src/io/json.cpp
@@ -495,7 +495,7 @@ namespace fc
       size_t i = 0;
       for( auto itr = str.begin(); itr != str.end(); ++i,++itr )
       {
-         if( i % 128 == 0 ) yield(os);
+         if( i % json::escape_string_yeild_check_count == 0 ) yield(os);
          switch( *itr )
          {
             case '\b':        // \x08

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -778,22 +778,17 @@ string format_string( const string& frmt, const variant_object& args, bool minim
                      replaced = false;
                   } else {
                      try {
-                        const auto arg_str_size = minimize ? minimize_sub_max_size : json::max_length_limit;
-                        result += json::to_string(val->value(), fc::time_point::maximum(), fc::json::stringify_large_ints_and_doubles, arg_str_size);
+                        const auto max_length = minimize ? minimize_sub_max_size : json::max_length_limit;
+                        result += json::to_string(val->value(), fc::time_point::maximum(), max_length);
                      } catch (...) {
                         replaced = false;
                      }
                   }
                } else if( val->value().is_blob() ) {
-                  if( minimize && (result.size() >= minimize_max_size)) {
+                  if( minimize && val->value().get_blob().data.size() > minimize_sub_max_size ) {
                      replaced = false;
                   } else {
-                     const auto vstr = val->value().as_string();
-                     if ( minimize && (vstr.size() > minimize_sub_max_size)) {
-                        replaced = false;
-                     } else {
-                        result += vstr;
-                     }
+                     result += val->value().as_string();
                   }
                } else if( val->value().is_string() ) {
                   if( minimize && val->value().get_string().size() > minimize_sub_max_size ) {

--- a/src/variant.cpp
+++ b/src/variant.cpp
@@ -777,8 +777,8 @@ string format_string( const string& frmt, const variant_object& args, bool minim
                   if( minimize && (result.size() >= minimize_max_size)) {
                      replaced = false;
                   } else {
+                     const auto max_length = minimize ? minimize_sub_max_size : std::numeric_limits<uint64_t>::max();
                      try {
-                        const auto max_length = minimize ? minimize_sub_max_size : json::max_length_limit;
                         result += json::to_string(val->value(), fc::time_point::maximum(), max_length);
                      } catch (...) {
                         replaced = false;

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_executable( test_io test_cfile.cpp)
+add_executable( test_io test_cfile.cpp )
 target_link_libraries( test_io fc )
 
+add_executable( test_json test_json.cpp )
+target_link_libraries( test_json fc )
+
 add_test(NAME test_io COMMAND libraries/fc/test/io/test_io WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME test_json COMMAND libraries/fc/test/io/test_io WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+

--- a/test/io/CMakeLists.txt
+++ b/test/io/CMakeLists.txt
@@ -1,10 +1,10 @@
-add_executable( test_io test_cfile.cpp )
-target_link_libraries( test_io fc )
+add_executable( test_cfile test_cfile.cpp )
+target_link_libraries( test_cfile fc )
 
 add_executable( test_json test_json.cpp )
 target_link_libraries( test_json fc )
 
-add_test(NAME test_io COMMAND libraries/fc/test/io/test_io WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME test_cfile COMMAND libraries/fc/test/io/test_io WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME test_json COMMAND libraries/fc/test/io/test_io WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 

--- a/test/io/test_json.cpp
+++ b/test/io/test_json.cpp
@@ -1,0 +1,369 @@
+#define BOOST_TEST_MODULE io_json
+#include <boost/test/included/unit_test.hpp>
+
+#include <fc/io/json.hpp>
+#include <fc/exception/exception.hpp>
+
+using namespace fc;
+
+BOOST_AUTO_TEST_SUITE(json_test_suite)
+
+namespace json_test_util {
+   constexpr size_t exception_limit_size = 250;
+
+   const json::yield_func yield_deadline_exception_at_start = [](std::ostream& os) {
+      throw fc::timeout_exception(fc::exception_code::timeout_exception_code, "timeout_exception", "execution timed out" );
+   };
+
+   const json::yield_func yield_deadline_exception_in_mid = [](std::ostream& os) {
+      if (os.tellp() >= exception_limit_size) {
+         throw fc::timeout_exception(fc::exception_code::timeout_exception_code, "timeout_exception", "execution timed out" );
+      }
+   };
+
+   const json::yield_func yield_length_exception = [](std::ostream& os) {
+      FC_ASSERT( os.tellp() <= exception_limit_size );
+   };
+
+   const json::yield_func yield_no_limitation = [](std::ostream& os) {
+      // no limitation
+   };
+
+   const auto time_except_verf_func = [](const fc::timeout_exception& ex) -> bool {
+      return (static_cast<int>(ex.code_value) == static_cast<int>(fc::exception_code::timeout_exception_code));
+   };
+
+   const auto length_limit_except_verf_func = [](const fc::assert_exception& ex) -> bool {
+      return (static_cast<int>(ex.code_value) == static_cast<int>(fc::exception_code::assert_exception_code));
+   };
+
+   constexpr size_t repeat_char_num = 512;
+   const std::string repeat_chars(repeat_char_num, 'a');
+   const string escape_input_str = "\\b\\f\\n\\r\\t-\\-\\\\-\\x0\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09\\x0a\\x0b\\x0c\\x0d\\x0e\\x0f"  \
+                                   "\\x10\\x11\\x12\\x13\\x14\\x15\\x16\\x17\\x18\\x19\\x1a\\x1b\\x1c\\x1d\\x1e\\x1f-" + repeat_chars;
+
+   const auto multiple_num = [](const size_t num, const size_t base) -> size_t {
+      return (num / base + ((num % base == 0) ? 0 : 1)) * base;
+   };
+
+}  // namespace json_test_util
+
+BOOST_AUTO_TEST_CASE(to_stream_test)
+{
+   {
+      // to_stream( ostream& out, const fc::string&, const yield_func& yield );
+      std::stringstream escape_out_str_ss;
+      fc::escape_string(json_test_util::escape_input_str, escape_out_str_ss, json_test_util::yield_no_limitation);
+      const auto size_different = escape_out_str_ss.str().size() - json_test_util::escape_input_str.size();
+      const auto expected_out_str_size = json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count) + size_different - 1;
+      BOOST_CHECK_LT(json_test_util::repeat_char_num, json_test_util::escape_input_str.size());
+      BOOST_CHECK_LT(json_test_util::escape_input_str.size() - json_test_util::repeat_char_num, json_test_util::exception_limit_size);  // by using size_different to calculate expected string
+      {
+         std::stringstream deadline_exception_at_start_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_at_start_ss, json_test_util::escape_input_str, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_ss.str(), "\"");
+      }
+      {
+         std::stringstream deadline_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_in_mid_ss, json_test_util::escape_input_str, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_ss.str(), escape_out_str_ss.str().substr(0, expected_out_str_size));
+      }
+      {
+         std::stringstream length_except_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream(length_except_mid_ss, json_test_util::escape_input_str, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_except_mid_ss.str(), escape_out_str_ss.str().substr(0, expected_out_str_size));
+      }
+   }
+   {
+      // to_stream( ostream& out, const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles );
+      {
+         variant v(json_test_util::escape_input_str);
+         std::stringstream deadline_exception_at_start_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_at_start_ss, v, fc::time_point::min(), json::max_length_limit),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_ss.str().empty(), true);
+      }
+      {
+         constexpr size_t max_len = 10;
+         variant v(json_test_util::repeat_chars);
+         std::stringstream length_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( length_exception_in_mid_ss, v, fc::time_point::maximum(), max_len),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_ss.str(),
+                           "\"" + json_test_util::repeat_chars.substr(0, json_test_util::multiple_num(max_len, json::escape_string_yeild_check_count)));
+      }
+      {
+         variant v(json_test_util::repeat_chars);
+         std::stringstream length_exception_in_mid_ss;
+         BOOST_CHECK_NO_THROW(json::to_stream( length_exception_in_mid_ss, v, fc::time_point::maximum(), json::max_length_limit));
+         BOOST_CHECK_EQUAL(length_exception_in_mid_ss.str(), "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+   {
+      // to_stream( ostream& out, const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+      const variant v(json_test_util::repeat_chars);
+      BOOST_CHECK_LT(json_test_util::exception_limit_size, json_test_util::repeat_chars.size());
+      {
+         std::stringstream deadline_exception_at_start_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_at_start_ss, v, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_ss.str().empty(), true);
+      }
+      {
+         std::stringstream deadline_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_in_mid_ss, v, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_ss.str(),
+                           "\"" + json_test_util::repeat_chars.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream length_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( length_exception_in_mid_ss, v, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_ss.str(),
+                           "\"" + json_test_util::repeat_chars.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream no_exception_ss;
+         BOOST_CHECK_NO_THROW(json::to_stream( no_exception_ss, v, json_test_util::yield_no_limitation));
+         BOOST_CHECK_EQUAL(no_exception_ss.str(), "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+   {
+      // to_stream( ostream& out, const variants& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+      const std::string a_list(json_test_util::repeat_char_num, 'a');
+      const std::string b_list(json_test_util::repeat_char_num, 'b');
+      const variants variant_list{variant(a_list), variant(b_list)};
+      BOOST_CHECK_LT(json_test_util::exception_limit_size, a_list.size() + b_list.size());
+      {
+         std::stringstream deadline_exception_at_start_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_at_start_ss, variant_list, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_ss.str().empty(), true);
+      }
+      {
+         std::stringstream deadline_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_in_mid_ss, variant_list, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_ss.str(),
+                           "[\"" + a_list.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream length_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( length_exception_in_mid_ss, variant_list, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_ss.str(),
+                           "[\"" + a_list.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream no_exception_ss;
+         BOOST_CHECK_NO_THROW(json::to_stream( no_exception_ss, variant_list, json_test_util::yield_no_limitation));
+         BOOST_CHECK_EQUAL(no_exception_ss.str(), "[\"" + a_list + "\",\"" + b_list + "\"]");
+      }
+   }
+   {
+      // to_stream( ostream& out, const variant_object& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+      const std::string a_list(json_test_util::repeat_char_num, 'a');
+      const std::string b_list(json_test_util::repeat_char_num, 'b');
+      const variant_object vo(mutable_variant_object()("a", a_list)("b", b_list));
+      BOOST_CHECK_LT(json_test_util::exception_limit_size, a_list.size() + b_list.size());
+      {
+         std::stringstream deadline_exception_at_start_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_at_start_ss, vo, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_ss.str().empty(), true);
+      }
+      {
+         std::stringstream deadline_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( deadline_exception_in_mid_ss, vo, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_ss.str(),
+                           "{\"a\":\"" + a_list.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream length_exception_in_mid_ss;
+         BOOST_CHECK_EXCEPTION(json::to_stream( length_exception_in_mid_ss, vo, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_ss.str(),
+                           "{\"a\":\"" + a_list.substr(0, json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count)));
+      }
+      {
+         std::stringstream no_exception_ss;
+         BOOST_CHECK_NO_THROW(json::to_stream( no_exception_ss, vo, json_test_util::yield_no_limitation));
+         BOOST_CHECK_EQUAL(no_exception_ss.str(), "{\"a\":\"" + a_list + "\",\"b\":\"" + b_list + "\"}");
+      }
+   }
+}
+
+BOOST_AUTO_TEST_CASE(to_string_test)
+{
+   {  // to_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles);
+      {
+         variant v(json_test_util::escape_input_str);
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_string( v, fc::time_point::min(), json::max_length_limit),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         constexpr size_t max_len = 10;
+         variant v(json_test_util::repeat_chars);
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_string( v, fc::time_point::maximum(), max_len),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         variant v(json_test_util::repeat_chars);
+         std::string length_exception_in_mid_str;
+         BOOST_CHECK_NO_THROW(length_exception_in_mid_str = json::to_string( v, fc::time_point::maximum(), json::max_length_limit));
+         BOOST_CHECK_EQUAL(length_exception_in_mid_str, "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+   {  // to_string( const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles);
+      const variant v(json_test_util::repeat_chars);
+      BOOST_CHECK_LT(json_test_util::exception_limit_size, json_test_util::repeat_chars.size());
+      {
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_string( v, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         std::string deadline_exception_in_mid_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_in_mid_str = json::to_string( v, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_str.empty(), true);
+      }
+      {
+         std::string length_exception_in_mid_str;
+         BOOST_CHECK_EXCEPTION(length_exception_in_mid_str = json::to_string( v, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_str.empty(), true);
+      }
+      {
+         std::string no_exception_str;
+         BOOST_CHECK_NO_THROW(no_exception_str = json::to_string( v, json_test_util::yield_no_limitation));
+         BOOST_CHECK_EQUAL(no_exception_str, "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+}
+
+BOOST_AUTO_TEST_CASE(to_pretty_string_test)
+{
+   {  // to_pretty_string( const variant& v, const fc::time_point& deadline, const uint64_t max_len = max_length_limit, output_formatting format = stringify_large_ints_and_doubles );
+      {
+         variant v(json_test_util::escape_input_str);
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_pretty_string( v, fc::time_point::min(), json::max_length_limit),
+         fc::timeout_exception,
+         json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         constexpr size_t max_len = 10;
+         variant v(json_test_util::repeat_chars);
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_pretty_string( v, fc::time_point::maximum(), max_len),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         variant v(json_test_util::repeat_chars);
+         std::string length_exception_in_mid_str;
+         BOOST_CHECK_NO_THROW(length_exception_in_mid_str = json::to_pretty_string( v, fc::time_point::maximum(), json::max_length_limit));
+         BOOST_CHECK_EQUAL(length_exception_in_mid_str, "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+   {  // to_pretty_string( const variant& v, const yield_func& yield, output_formatting format = stringify_large_ints_and_doubles );
+      const variant v(json_test_util::repeat_chars);
+      BOOST_CHECK_LT(json_test_util::exception_limit_size, json_test_util::repeat_chars.size());
+      {
+         std::string deadline_exception_at_start_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_at_start_str = json::to_pretty_string( v, json_test_util::yield_deadline_exception_at_start),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_at_start_str.empty(), true);
+      }
+      {
+         std::string deadline_exception_in_mid_str;
+         BOOST_CHECK_EXCEPTION(deadline_exception_in_mid_str = json::to_pretty_string( v, json_test_util::yield_deadline_exception_in_mid),
+                               fc::timeout_exception,
+                               json_test_util::time_except_verf_func);
+         BOOST_CHECK_EQUAL(deadline_exception_in_mid_str.empty(), true);
+      }
+      {
+         std::string length_exception_in_mid_str;
+         BOOST_CHECK_EXCEPTION(length_exception_in_mid_str = json::to_pretty_string( v, json_test_util::yield_length_exception),
+                               fc::assert_exception,
+                               json_test_util::length_limit_except_verf_func);
+         BOOST_CHECK_EQUAL(length_exception_in_mid_str.empty(), true);
+      }
+      {
+         std::string no_exception_str;
+         BOOST_CHECK_NO_THROW(no_exception_str = json::to_pretty_string( v, json_test_util::yield_no_limitation));
+         BOOST_CHECK_EQUAL(no_exception_str, "\"" + json_test_util::repeat_chars + "\"");
+      }
+   }
+}
+
+BOOST_AUTO_TEST_CASE(escape_string_test)
+{
+   std::stringstream escape_out_str_ss;
+   fc::escape_string(json_test_util::escape_input_str, escape_out_str_ss, json_test_util::yield_no_limitation);
+   const auto size_different = escape_out_str_ss.str().size() - json_test_util::escape_input_str.size();
+   const auto expected_out_str_size = json_test_util::multiple_num(json_test_util::exception_limit_size, json::escape_string_yeild_check_count) + size_different - 1;
+   BOOST_CHECK_LT(json_test_util::repeat_char_num, json_test_util::escape_input_str.size());
+   BOOST_CHECK_LT(json_test_util::escape_input_str.size() - json_test_util::repeat_char_num, json_test_util::exception_limit_size);  // by using size_different to calculate expected string
+   {
+      // simulate exceed time exception at the beginning of processing
+      std::stringstream escape_time_except_begin_ss;
+      BOOST_CHECK_EXCEPTION(escape_string(json_test_util::escape_input_str, escape_time_except_begin_ss, json_test_util::yield_deadline_exception_at_start),
+                            fc::timeout_exception,
+                            json_test_util::time_except_verf_func);
+      BOOST_CHECK_EQUAL(escape_time_except_begin_ss.str(), "\"");
+   }
+   {
+      // simulate exceed time exception in the middle of processing
+      std::stringstream escape_time_except_mid_ss;
+      BOOST_CHECK_EXCEPTION(escape_string(json_test_util::escape_input_str, escape_time_except_mid_ss, json_test_util::yield_deadline_exception_in_mid),
+                            fc::timeout_exception,
+                            json_test_util::time_except_verf_func);
+      BOOST_CHECK_EQUAL(escape_time_except_mid_ss.str(), escape_out_str_ss.str().substr(0, expected_out_str_size));
+   }
+   {
+      // length limitation exception in the middle of processing
+      std::stringstream length_except_mid_ss;
+      BOOST_CHECK_EXCEPTION(escape_string(json_test_util::escape_input_str, length_except_mid_ss, json_test_util::yield_length_exception),
+                            fc::assert_exception,
+                            json_test_util::length_limit_except_verf_func);
+      BOOST_CHECK_EQUAL(length_except_mid_ss.str(), escape_out_str_ss.str().substr(0, expected_out_str_size));
+   }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/variant/test_variant.cpp
+++ b/test/variant/test_variant.cpp
@@ -3,7 +3,7 @@
 
 #include <fc/variant_object.hpp>
 #include <fc/exception/exception.hpp>
-
+#include <fc/crypto/base64.hpp>
 #include <string>
 
 using namespace fc;
@@ -31,4 +31,68 @@ BOOST_AUTO_TEST_CASE(mutable_variant_object_test)
   FC_LOG_AND_RETHROW();
 }
 
+BOOST_AUTO_TEST_CASE(variant_format_string_limited)
+{
+   constexpr size_t long_rep_char_num = 1024;
+   const std::string a_long_list = std::string(long_rep_char_num, 'a');
+   const std::string b_long_list = std::string(long_rep_char_num, 'b');
+   {
+      const string format = "${a} ${b} ${c}";
+      fc::mutable_variant_object mu;
+      mu( "a", string( long_rep_char_num, 'a' ) );
+      mu( "b", string( long_rep_char_num, 'b' ) );
+      mu( "c", string( long_rep_char_num, 'c' ) );
+      const string result = fc::format_string( format, mu, true );
+      BOOST_CHECK_LT(0, mu.size());
+      const auto arg_limit_size = (1024 - format.size()) / mu.size();
+      BOOST_CHECK_EQUAL( result, string(arg_limit_size, 'a' ) + "... " + string(arg_limit_size, 'b' ) + "... " + string(arg_limit_size, 'c' ) + "..." );
+      BOOST_CHECK_LT(result.size(), 1024 + 3 * mu.size());
+   }
+   {  // verify object, array, blob, and string, all exceeds limits, fold display for each
+      fc::mutable_variant_object mu;
+      mu( "str", a_long_list );
+      mu( "obj", variant_object(mutable_variant_object()("a", a_long_list)("b", b_long_list)) );
+      mu( "arr", variants{variant(a_long_list), variant(b_long_list)} );
+      mu( "blob", blob({std::vector<char>(a_long_list.begin(), a_long_list.end())}) );
+      const string format_prefix = "Format string test: ";
+      const string format_str = format_prefix + "${str} ${obj} ${arr} {blob}";
+      const string result = fc::format_string( format_str, mu, true );
+      BOOST_CHECK_LT(0, mu.size());
+      const auto arg_limit_size = (1024 - format_str.size()) / mu.size();
+      BOOST_CHECK_EQUAL( result, format_prefix + a_long_list.substr(0, arg_limit_size) + "..." + " ${obj} ${arr} {blob}");
+      BOOST_CHECK_LT(result.size(), 1024 + 3 * mu.size());
+   }
+   {  // verify object, array can be displayed properly
+      const string format_prefix = "Format string test: ";
+      const string format_str = format_prefix + "${str} ${obj} ${arr} ${blob} ${var}";
+      BOOST_CHECK_LT(format_str.size(), 1024);
+      const size_t short_rep_char_num = (1024 - format_str.size()) / 5 - 1;
+      const std::string a_short_list = std::string(short_rep_char_num, 'a');
+      const std::string b_short_list = std::string(short_rep_char_num / 3, 'b');
+      const std::string c_short_list = std::string(short_rep_char_num / 3, 'c');
+      const std::string d_short_list = std::string(short_rep_char_num / 3, 'd');
+      const std::string e_short_list = std::string(short_rep_char_num / 3, 'e');
+      const std::string f_short_list = std::string(short_rep_char_num, 'f');
+      const std::string g_short_list = std::string(short_rep_char_num, 'g');
+      fc::mutable_variant_object mu;
+      const variant_object vo(mutable_variant_object()("b", b_short_list)("c", c_short_list));
+      const variants variant_list{variant(d_short_list), variant(e_short_list)};
+      const blob a_blob({std::vector<char>(f_short_list.begin(), f_short_list.end())});
+      const variant a_variant(g_short_list);
+      mu( "str",  a_short_list );
+      mu( "obj",  vo);
+      mu( "arr",  variant_list);
+      mu( "blob", a_blob);
+      mu( "var",  a_variant);
+      const string result = fc::format_string( format_str, mu, true );
+      const string target_result = format_prefix + a_short_list + " " +
+                                   "{" + "\"b\":\"" + b_short_list + "\",\"c\":\"" + c_short_list + "\"}" + " " +
+                                   "[\"" + d_short_list + "\",\"" + e_short_list + "\"]" + " " +
+                                   base64_encode( a_blob.data.data(), a_blob.data.size() ) + "=" + " " +
+                                   g_short_list;
+
+      BOOST_CHECK_EQUAL( result, target_result);
+      BOOST_CHECK_LT(result.size(), 1024 + 3 * mu.size());
+   }
+}
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Issue #8741,

expand limited display for different data types when the minimize flag is set. "..." will be added when the argument limitation is set. The argument limitation is (1024 - format string length) / number of arguments.
