### PR TITLE
Use yield pattern instead of deadline - 2.0

### DIFF
--- a/include/fc/crypto/base58.hpp
+++ b/include/fc/crypto/base58.hpp
@@ -4,8 +4,8 @@
 #include <vector>
 
 namespace fc {
-    std::string to_base58( const char* d, size_t s, const fc::time_point& deadline );
-    std::string to_base58( const std::vector<char>& data, const fc::time_point& deadline );
+    std::string to_base58( const char* d, size_t s, const fc::yield_function_t& yield );
+    std::string to_base58( const std::vector<char>& data, const fc::yield_function_t& yield );
     std::vector<char> from_base58( const std::string& base58_str );
     size_t from_base58( const std::string& base58_str, char* out_data, size_t out_data_len );
 }

--- a/include/fc/crypto/common.hpp
+++ b/include/fc/crypto/common.hpp
@@ -87,8 +87,8 @@ namespace fc { namespace crypto {
 
    template<typename Storage, const char * const * Prefixes, int DefaultPosition = -1>
    struct base58str_visitor : public fc::visitor<std::string> {
-      explicit base58str_visitor( const fc::time_point& deadline )
-      : _deadline(deadline) {};
+      explicit base58str_visitor( const fc::yield_function_t& yield )
+      : _yield(yield) {};
       template< typename KeyType >
       std::string operator()( const KeyType& key ) const {
          using data_type = typename KeyType::data_type;
@@ -97,21 +97,21 @@ namespace fc { namespace crypto {
 
          checksummed_data<data_type> wrapper;
          wrapper.data = key.serialize();
-         FC_CHECK_DEADLINE(_deadline);
+         _yield();
          wrapper.check = checksummed_data<data_type>::calculate_checksum(wrapper.data, !is_default ? Prefixes[position] : nullptr);
-         FC_CHECK_DEADLINE(_deadline);
+         _yield();
          auto packed = raw::pack( wrapper );
-         FC_CHECK_DEADLINE(_deadline);
-         auto data_str = to_base58( packed.data(), packed.size(), _deadline );
-         FC_CHECK_DEADLINE(_deadline);
+         _yield();
+         auto data_str = to_base58( packed.data(), packed.size(), _yield );
+         _yield();
          if (!is_default) {
             data_str = string(Prefixes[position]) + "_" + data_str;
          }
-         FC_CHECK_DEADLINE(_deadline);
+         _yield();
 
          return data_str;
       }
-      const fc::time_point _deadline;
+      const fc::yield_function_t _yield;
    };
 
    template<typename T>

--- a/include/fc/crypto/private_key.hpp
+++ b/include/fc/crypto/private_key.hpp
@@ -47,7 +47,7 @@ namespace fc { namespace crypto {
 
          // serialize to/from string
          explicit private_key(const string& base58str);
-         std::string to_string(const fc::time_point& deadline = fc::time_point::maximum()) const;
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
 
       private:
          storage_type _storage;
@@ -65,7 +65,7 @@ namespace fc { namespace crypto {
 } }  // fc::crypto
 
 namespace fc {
-   void to_variant(const crypto::private_key& var, variant& vo, const fc::time_point& deadline = fc::time_point::maximum());
+   void to_variant(const crypto::private_key& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
 
    void from_variant(const variant& var, crypto::private_key& vo);
 } // namespace fc

--- a/include/fc/crypto/public_key.hpp
+++ b/include/fc/crypto/public_key.hpp
@@ -40,7 +40,7 @@ namespace fc { namespace crypto {
 
          // serialize to/from string
          explicit public_key(const string& base58str);
-         std::string to_string(const fc::time_point& deadline = fc::time_point::maximum()) const;
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
 
          storage_type _storage;
 
@@ -56,7 +56,7 @@ namespace fc { namespace crypto {
 } }  // fc::crypto
 
 namespace fc {
-   void to_variant(const crypto::public_key& var, variant& vo, const fc::time_point& deadline = fc::time_point::maximum());
+   void to_variant(const crypto::public_key& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
 
    void from_variant(const variant& var, crypto::public_key& vo);
 } // namespace fc

--- a/include/fc/crypto/signature.hpp
+++ b/include/fc/crypto/signature.hpp
@@ -28,7 +28,7 @@ namespace fc { namespace crypto {
 
          // serialize to/from string
          explicit signature(const string& base58str);
-         std::string to_string(const fc::time_point& deadline = fc::time_point::maximum()) const;
+         std::string to_string(const fc::yield_function_t& yield = fc::yield_function_t()) const;
 
          int which() const;
 
@@ -55,7 +55,7 @@ namespace fc { namespace crypto {
 } }  // fc::crypto
 
 namespace fc {
-   void to_variant(const crypto::signature& var, variant& vo, const fc::time_point& deadline = fc::time_point::maximum());
+   void to_variant(const crypto::signature& var, variant& vo, const fc::yield_function_t& yield = fc::yield_function_t());
 
    void from_variant(const variant& var, crypto::signature& vo);
 } // namespace fc

--- a/include/fc/io/json.hpp
+++ b/include/fc/io/json.hpp
@@ -2,6 +2,7 @@
 #include <fc/variant.hpp>
 #include <fc/filesystem.hpp>
 #include <fc/time.hpp>
+#include <fc/utility.hpp>
 #include <fc/exception/exception.hpp>
 
 #define DEFAULT_MAX_RECURSION_DEPTH 200
@@ -30,7 +31,7 @@ namespace fc
             stringify_large_ints_and_doubles = 0,
             legacy_generator = 1
          };
-         using yield_function_t = std::function<void(std::ostream&)>;
+         using yield_function_t = fc::optional_delegate<void(std::ostream&)>;
          static constexpr uint64_t max_length_limit = std::numeric_limits<uint64_t>::max();
          static constexpr size_t escape_string_yeild_check_count = 128;
          static ostream& to_stream( ostream& out, const fc::string&, const yield_function_t& yield );

--- a/include/fc/utility.hpp
+++ b/include/fc/utility.hpp
@@ -187,22 +187,17 @@ namespace fc {
   public:
      using std::function<R(Args...)>::function;
 
-     /**
-      * overloaded call operator to ignore unset functions
-      */
-     template<typename U = R>
-     auto operator()( Args... args ) const -> std::enable_if_t<!std::is_void_v<U>, R> {
+     auto operator()( Args... args ) const -> R {
         if (static_cast<bool>(*this)) {
-           return std::function<R(Args...)>::operator()(std::move(args)...);
+           if constexpr( std::is_move_constructible_v<R> ) {
+              return std::function<R(Args...)>::operator()(std::move(args)...);
+           } else {
+              return std::function<R(Args...)>::operator()(args...);
+           }
         } else {
-           return {};
-        }
-     }
-
-     template<typename U = R>
-     auto operator()( Args... args ) const -> std::enable_if_t<std::is_void_v<U>> {
-        if (static_cast<bool>(*this)) {
-           std::function<R(Args...)>::operator()(std::move(args)...);
+           if constexpr( !std::is_void_v<R> ) {
+              return {};
+           }
         }
      }
   };

--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -356,7 +356,7 @@ namespace fc
         explicit variant( const T& val );
 
         template<typename T>
-        explicit variant( const T& val, const fc::time_point& deadline );
+        explicit variant( const T& val, const fc::yield_function_t& yield );
 
         void    clear();
       private:
@@ -594,10 +594,10 @@ namespace fc
    }
 
    template<typename T>
-   variant::variant( const T& val, const fc::time_point& deadline )
+   variant::variant( const T& val, const fc::yield_function_t& yield )
    {
       memset( this, 0, sizeof(*this) );
-      to_variant( val, *this, deadline );
+      to_variant( val, *this, yield );
    }
 
    #ifdef __APPLE__

--- a/src/crypto/elliptic_common.cpp
+++ b/src/crypto/elliptic_common.cpp
@@ -134,7 +134,7 @@ namespace fc { namespace ecc {
       array<char, 37> data;
       memcpy(data.data, key.begin(), key.size());
       memcpy(data.begin() + key.size(), (const char*)&check, sizeof(check));
-      return fc::to_base58(data.begin(), data.size(), fc::time_point::maximum());
+      return fc::to_base58(data.begin(), data.size(), fc::yield_function_t());
     }
 
     public_key public_key::from_base58( const std::string& b58 )

--- a/src/crypto/elliptic_r1.cpp
+++ b/src/crypto/elliptic_r1.cpp
@@ -319,7 +319,7 @@ namespace fc { namespace crypto { namespace r1 {
       array<char, 37> data;
       memcpy(data.data, key.begin(), key.size());
       memcpy(data.begin() + key.size(), (const char*)&check, sizeof(check));
-      return fc::to_base58(data.begin(), data.size(), fc::time_point::maximum());
+      return fc::to_base58(data.begin(), data.size(), fc::yield_function_t());
     }
 
     public_key public_key::from_base58( const std::string& b58 )

--- a/src/crypto/private_key.cpp
+++ b/src/crypto/private_key.cpp
@@ -60,7 +60,7 @@ namespace fc { namespace crypto {
    }
 
    template<typename Data>
-   string to_wif( const Data& secret, const fc::time_point& deadline )
+   string to_wif( const Data& secret, const fc::yield_function_t& yield )
    {
       const size_t size_of_data_to_hash = sizeof(typename Data::data_type) + 1;
       const size_t size_of_hash_bytes = 4;
@@ -70,7 +70,7 @@ namespace fc { namespace crypto {
       sha256 digest = sha256::hash(data, size_of_data_to_hash);
       digest = sha256::hash(digest);
       memcpy(data + size_of_data_to_hash, (char*)&digest, size_of_hash_bytes);
-      return to_base58(data, sizeof(data), deadline);
+      return to_base58(data, sizeof(data), yield);
    }
 
    template<typename Data>
@@ -111,16 +111,16 @@ namespace fc { namespace crypto {
    :_storage(parse_base58(base58str))
    {}
 
-   std::string private_key::to_string(const fc::time_point& deadline) const
+   std::string private_key::to_string(const fc::yield_function_t& yield) const
    {
       auto which = _storage.which();
 
       if (which == 0) {
          using default_type = storage_type::template type_at<0>;
-         return to_wif(_storage.template get<default_type>(), deadline);
+         return to_wif(_storage.template get<default_type>(), yield);
       }
 
-      auto data_str = _storage.visit(base58str_visitor<storage_type, config::private_key_prefix>(deadline));
+      auto data_str = _storage.visit(base58str_visitor<storage_type, config::private_key_prefix>(yield));
       return std::string(config::private_key_base_prefix) + "_" + data_str;
    }
 
@@ -141,9 +141,9 @@ namespace fc { namespace crypto {
 
 namespace fc
 {
-   void to_variant(const fc::crypto::private_key& var, variant& vo, const fc::time_point& deadline)
+   void to_variant(const fc::crypto::private_key& var, variant& vo, const fc::yield_function_t& yield)
    {
-      vo = var.to_string(deadline);
+      vo = var.to_string(yield);
    }
 
    void from_variant(const variant& var, fc::crypto::private_key& vo)

--- a/src/crypto/public_key.cpp
+++ b/src/crypto/public_key.cpp
@@ -72,9 +72,9 @@ namespace fc { namespace crypto {
       return _storage.visit(is_valid_visitor());
    }
 
-   std::string public_key::to_string(const fc::time_point& deadline) const
+   std::string public_key::to_string(const fc::yield_function_t& yield) const
    {
-      auto data_str = _storage.visit(base58str_visitor<storage_type, config::public_key_prefix, 0>(deadline));
+      auto data_str = _storage.visit(base58str_visitor<storage_type, config::public_key_prefix, 0>(yield));
 
       auto which = _storage.which();
       if (which == 0) {
@@ -106,9 +106,9 @@ namespace fc { namespace crypto {
 namespace fc
 {
    using namespace std;
-   void to_variant(const fc::crypto::public_key& var, fc::variant& vo, const fc::time_point& deadline)
+   void to_variant(const fc::crypto::public_key& var, fc::variant& vo, const fc::yield_function_t& yield)
    {
-      vo = var.to_string(deadline);
+      vo = var.to_string(yield);
    }
 
    void from_variant(const fc::variant& var, fc::crypto::public_key& vo)

--- a/src/crypto/signature.cpp
+++ b/src/crypto/signature.cpp
@@ -53,10 +53,10 @@ namespace fc { namespace crypto {
       });
    }
 
-   std::string signature::to_string(const fc::time_point& deadline) const
+   std::string signature::to_string(const fc::yield_function_t& yield) const
    {
-      auto data_str = _storage.visit(base58str_visitor<storage_type, config::signature_prefix>(deadline));
-      FC_CHECK_DEADLINE(deadline);
+      auto data_str = _storage.visit(base58str_visitor<storage_type, config::signature_prefix>(yield));
+      yield();
       return std::string(config::signature_base_prefix) + "_" + data_str;
    }
 
@@ -85,9 +85,9 @@ namespace fc { namespace crypto {
 
 namespace fc
 {
-   void to_variant(const fc::crypto::signature& var, fc::variant& vo, const fc::time_point& deadline)
+   void to_variant(const fc::crypto::signature& var, fc::variant& vo, const fc::yield_function_t& yield)
    {
-      vo = var.to_string(deadline);
+      vo = var.to_string(yield);
    }
 
    void from_variant(const fc::variant& var, fc::crypto::signature& vo)


### PR DESCRIPTION
Move to using a yield function instead of a deadline for greater flexibility in determining when to stop processing.

v2.0.x version of #149 