### PR TITLE
place the rapidjson used for webauthn parsing in to a unique namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ target_include_directories(fc
 if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11.0)
    set_source_files_properties(src/crypto/elliptic_webauthn.cpp PROPERTIES INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}/include/fc/crypto/webauthn_json/include)
 else()
-   target_include_directories(fc PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/fc/crypto/webauthn_json/include)
+   set_source_files_properties(src/crypto/elliptic_webauthn.cpp PROPERTIES COMPILE_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/include/fc/crypto/webauthn_json/include")
 endif()
 
 IF(NOT WIN32)

--- a/src/crypto/elliptic_webauthn.cpp
+++ b/src/crypto/elliptic_webauthn.cpp
@@ -7,7 +7,10 @@
 #include <fc/exception/exception.hpp>
 #include <fc/log/logger.hpp>
 
+#define RAPIDJSON_NAMESPACE_BEGIN namespace fc::crypto::webauthn::detail::rapidjson {
+#define RAPIDJSON_NAMESPACE_END }
 #include "rapidjson/reader.h"
+
 #include <string>
 
 namespace fc { namespace crypto { namespace webauthn {
@@ -185,9 +188,9 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
 
 public_key::public_key(const signature& c, const fc::sha256& digest, bool) {
    detail::webauthn_json_handler handler;
-   rapidjson::Reader reader;
-   rapidjson::StringStream ss(c.client_json.c_str());
-   FC_ASSERT(reader.Parse<rapidjson::kParseIterativeFlag>(ss, handler), "Failed to parse client data JSON");
+   detail::rapidjson::Reader reader;
+   detail::rapidjson::StringStream ss(c.client_json.c_str());
+   FC_ASSERT(reader.Parse<detail::rapidjson::kParseIterativeFlag>(ss, handler), "Failed to parse client data JSON");
 
    FC_ASSERT(handler.found_type == "webauthn.get", "webauthn signature type not an assertion");
 


### PR DESCRIPTION
... so that any other rapidjson in eosio (or really any other consumer of fc) doesn't suffer from any conflicts