### PR TITLE
clear old elements before copy data when unpack to std::set

### DIFF
--- a/include/fc/io/raw.hpp
+++ b/include/fc/io/raw.hpp
@@ -599,6 +599,7 @@ namespace fc {
     inline void unpack( Stream& s, std::set<T>& value ) {
       unsigned_int size; fc::raw::unpack( s, size );
       FC_ASSERT( size.value <= MAX_NUM_ARRAY_ELEMENTS );
+      value.clear();
       for( uint64_t i = 0; i < size.value; ++i )
       {
         T tmp;


### PR DESCRIPTION
old data should be cleared when unpack to existing std::set objects.