### PR TITLE
Fix variant type blob unpack bug

### DIFF
--- a/include/fc/io/raw_variant.hpp
+++ b/include/fc/io/raw_variant.hpp
@@ -119,6 +119,7 @@ namespace fc { namespace raw {
             blob val;
             raw::unpack(s,val);
             v = fc::move(val);
+            return;
          }
          default:
             FC_THROW_EXCEPTION( parse_error_exception, "Unknown Variant Type ${t}", ("t", t) );


### PR DESCRIPTION
Hi, I run a fork of EOSIO that (de-)serializes the `fc::blob` variant_type and came across this error.

The `unpack` function is missing a `return;` in the switch which makes it fall through to the `default` case for the blob variant type. Which then crashes with the `Unknown Variant Type 8` error.