### PR TITLE
Fix variant type blob unpack bug - 2.0

### DIFF
--- a/include/fc/io/raw_variant.hpp
+++ b/include/fc/io/raw_variant.hpp
@@ -119,6 +119,7 @@ namespace fc { namespace raw {
             blob val;
             raw::unpack(s,val);
             v = fc::move(val);
+            return;
          }
          default:
             FC_THROW_EXCEPTION( parse_error_exception, "Unknown Variant Type ${t}", ("t", t) );


### PR DESCRIPTION
v2.0.x version of https://github.com/EOSIO/fc/pull/164

The unpack function is missing a return; in the switch which makes it fall through to the default case for the blob variant type. Which then crashes with the Unknown Variant Type 8 error.

Thanks @MrToph