### PR TITLE
Remove deprecated calls in openssl v1.1.0

### DIFF
--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -37,8 +37,10 @@ namespace  fc
        }
        openssl_scope()
        {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
           ERR_load_crypto_strings(); 
           OpenSSL_add_all_algorithms();
+#endif
 
           const boost::filesystem::path& boostPath = config_path();
           if(boostPath.empty() == false)
@@ -52,13 +54,17 @@ namespace  fc
 #endif
           }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
           OPENSSL_config(nullptr);
+#endif
        }
 
        ~openssl_scope()
        {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
           EVP_cleanup();
           ERR_free_strings();
+#endif
        }
     };
 


### PR DESCRIPTION
Since openssl v1.1.0, manual initialization and deinitialization are deprecated, and they will be handled automatically by repeated internal calls of openssl_init_crypto() etc.

This PR removes calling deprecated functions according to the version of openssl during compilation.