### PR TITLE
Allow conversion from variant_object to std::pair

### DIFF
--- a/include/fc/variant.hpp
+++ b/include/fc/variant.hpp
@@ -604,11 +604,16 @@ namespace fc
    template<typename A, typename B>
    void from_variant( const fc::variant& v, std::pair<A,B>& p )
    {
-      const variants& vars = v.get_array();
-      if( vars.size() > 0 )
-         vars[0].as<A>( p.first );
-      if( vars.size() > 1 )
-         vars[1].as<B>( p.second );
+      try {
+         const variants& vars = v.get_array();
+         if( vars.size() > 0 )
+            vars[0].as<A>( p.first );
+         if( vars.size() > 1 )
+            vars[1].as<B>( p.second );
+      } catch( ... ) {
+         v["first"].as<A>( p.first );
+         v["second"].as<B>( p.second );
+      }
    }
 
    template<typename T>


### PR DESCRIPTION
FC_REFLECT uses from_variant/to_variant pairs, so for extensions_type of `eosio::chain` (an alias of `std::vector<std::pair<uint16_t, std::vector<char>>>`) will try calling `fc::from_variant(const fc::variant& v, std::pair<A,B>  p)`.
However, eosio.cdt will generate ABI for std::pair like pair_A_B with two fields, first and second. `eosio::chain::abi_serializer` will accept object with two keys, "first" and "second", but fc::from_variant will require fc::variants (an alias of `std::vector<fc::variant>`) for `std::pair`.
This PR makes from_variant try parsing variant to variant_object when failing to parse variant to variants for `std::pair`.