### PR TITLE
avoid make_strand() as it's a boost 1.70 feature

### DIFF
--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -58,7 +58,7 @@ public:
    std::optional<url> endpoint;
    std::thread thread;
    boost::asio::io_context ctx;
-   boost::asio::strand<boost::asio::io_context::executor_type> work_strand = boost::asio::make_strand(ctx);
+   boost::asio::io_context::strand work_strand{ctx};
    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard = boost::asio::make_work_guard(ctx);
 
    impl( std::string url, std::string service_name, uint32_t timeout_us )


### PR DESCRIPTION
For this simple use case, can just use `boost::asio::io_context::strand` directly. Keeps fc building with 1.67 which its CMakeLists.txt specifies.