### PR TITLE
Make fc::copy compatible with boost 73

### DIFF
--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -248,10 +248,20 @@ namespace fc {
      boost::system::error_code ec;
      try {
         #if (BOOST_VERSION/100000) == 1 && ((BOOST_VERSION/100)%1000) > 73
-  	      boost::filesystem::copy( boost::filesystem::path(f), 
-                                   boost::filesystem::path(t), 
-                                   boost::filesystem::copy_options::directories_only, 
-                                   ec );
+          if (exists(t)){
+            throw boost::system::system_error(boost::system::errc::make_error_code(boost::system::errc::errc_t::file_exists));
+          }
+          if ( boost::filesystem::is_directory( f ) ) {
+            boost::filesystem::copy(boost::filesystem::path(f), 
+                                    boost::filesystem::path(t), 
+                                    boost::filesystem::copy_options::directories_only, 
+                                    ec );
+          } else {
+            boost::filesystem::copy(boost::filesystem::path(f), 
+                                    boost::filesystem::path(t), 
+                                    boost::filesystem::copy_options::none, 
+                                    ec );
+          }
         #else
   	      boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t), ec );
         #endif

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -247,7 +247,14 @@ namespace fc {
   void copy( const path& f, const path& t ) {
      boost::system::error_code ec;
      try {
+        #if (BOOST_VERSION/100000) == 1 && ((BOOST_VERSION/100)%1000) > 73
+  	      boost::filesystem::copy( boost::filesystem::path(f), 
+                                   boost::filesystem::path(t), 
+                                   boost::filesystem::copy_options::directories_only, 
+                                   ec );
+        #else
   	      boost::filesystem::copy( boost::filesystem::path(f), boost::filesystem::path(t), ec );
+        #endif
      } catch ( boost::system::system_error& e ) {
      	FC_THROW( "Copy from ${srcfile} to ${dstfile} failed because ${reason}",
 	         ("srcfile",f)("dstfile",t)("reason",e.what() ) );

--- a/src/filesystem.cpp
+++ b/src/filesystem.cpp
@@ -247,7 +247,7 @@ namespace fc {
   void copy( const path& f, const path& t ) {
      boost::system::error_code ec;
      try {
-        #if (BOOST_VERSION/100000) == 1 && ((BOOST_VERSION/100)%1000) > 73
+        #if BOOST_VERSION > 107300
           if (exists(t)){
             throw boost::system::system_error(boost::system::errc::make_error_code(boost::system::errc::errc_t::file_exists));
           }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,3 +9,8 @@ add_executable( test_base64 test_base64.cpp )
 target_link_libraries( test_base64 fc )
 
 add_test(NAME test_base64 COMMAND libraries/fc/test/test_base64 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_executable( test_filesystem test_filesystem.cpp )
+target_link_libraries( test_filesystem fc )
+
+add_test(NAME test_filesystem COMMAND libraries/fc/test/test_filesystem WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -1,0 +1,95 @@
+#define BOOST_TEST_MODULE fc_filesystem
+#include <boost/test/included/unit_test.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <fc/filesystem.hpp>
+#include <fc/exception/exception.hpp>
+
+using namespace fc;
+
+std::string getFileContent(const string& filename) {
+   string ret;
+   boost::filesystem::ifstream  ifs { filename };
+   ifs >> ret;
+   ifs.close();
+   return ret;
+}
+
+BOOST_AUTO_TEST_SUITE(fc_filesystem)
+
+BOOST_AUTO_TEST_CASE(dir_copy) try {
+   // 1. check whether dir can be copied when target dir does not exist, 
+   // but not recursively (compatible with 1.73)
+   
+   const string src_dir {"/tmp/fc_copy_test_src"};
+   if (!fc::exists(src_dir)) {
+      create_directories(src_dir);
+   }
+
+   BOOST_CHECK_EQUAL(fc::exists(src_dir), true);
+   const string test_file_name = "fc_copy_test_file";
+   if (!fc::exists(src_dir + "/" + test_file_name)) {
+      boost::filesystem::ofstream  ofs { src_dir + "/" + test_file_name};
+      ofs << "This the test of fc system copy \n";
+      ofs.close();
+   }
+   BOOST_CHECK_EQUAL(fc::exists(src_dir + "/" + test_file_name), true);
+      
+   const string tgt_dir {"/tmp/fc_copy_test_tgt"};
+   if (fc::exists(tgt_dir)) {
+      remove_all(tgt_dir);
+   }   
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir), false);
+  
+   fc::copy(src_dir, tgt_dir);
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir), true);
+   // check not copied recursively
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), false);
+   
+   // 2. check whether exception be thrown (no overwrite) when target dir does exist, 
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir), true);
+   BOOST_CHECK_EXCEPTION(fc::copy(src_dir, tgt_dir), fc::exception,  [](const fc::exception& e) {
+      return e.code() == fc::unspecified_exception_code;
+   });
+
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_CASE(file_copy) try {
+   // 1. check whether file can be copied when target file does not exist, 
+   const string src_dir {"/tmp/fc_copy_test_src"};
+   if (!fc::exists(src_dir)) {
+      create_directories(src_dir);
+   }
+
+   BOOST_CHECK_EQUAL(fc::exists(src_dir), true);
+   const string test_file_name = "fc_copy_test_file";
+   if (!fc::exists(src_dir + "/" + test_file_name)) {
+      boost::filesystem::ofstream  ofs { src_dir + "/" + test_file_name};
+      ofs << "This the test of fc system copy \n";
+      ofs.close();
+   }
+   BOOST_CHECK_EQUAL(fc::exists(src_dir + "/" + test_file_name), true);
+      
+   const string tgt_dir {"/tmp/fc_copy_test_tgt"};
+   if (!fc::exists(tgt_dir)) {
+      fc::copy(src_dir, tgt_dir);
+   }   
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir), true);
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), false);
+   fc::copy(src_dir + "/" + test_file_name, tgt_dir + "/" + test_file_name);
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), true);
+   const string src_file_content = getFileContent(src_dir + "/" + test_file_name);
+   BOOST_CHECK_EQUAL(src_file_content.empty(), false);
+   const string tgt_file_content = getFileContent(tgt_dir + "/" + test_file_name);
+   BOOST_CHECK_EQUAL(src_file_content, tgt_file_content);
+
+   // 2. check whether exception be thrown (no overwrite) when target file does exist, 
+   BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), true);
+   BOOST_CHECK_EXCEPTION(fc::copy(src_dir + "/" + test_file_name, tgt_dir + "/" + test_file_name), 
+                         fc::exception,  
+                         [](const fc::exception& e) {
+                              return e.code() == fc::unspecified_exception_code;
+                         });
+   
+} FC_LOG_AND_RETHROW();
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/test_filesystem.cpp
+++ b/test/test_filesystem.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(dir_copy) try {
    // check not copied recursively
    BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), false);
    
-   // 2. check whether exception be thrown (no overwrite) when target dir does exist, 
+   // 2. check whether exception be thrown (no overwritten) when target dir does exist, 
    BOOST_CHECK_EQUAL(fc::exists(tgt_dir), true);
    BOOST_CHECK_EXCEPTION(fc::copy(src_dir, tgt_dir), fc::exception,  [](const fc::exception& e) {
       return e.code() == fc::unspecified_exception_code;
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(file_copy) try {
    const string tgt_file_content = getFileContent(tgt_dir + "/" + test_file_name);
    BOOST_CHECK_EQUAL(src_file_content, tgt_file_content);
 
-   // 2. check whether exception be thrown (no overwrite) when target file does exist, 
+   // 2. check whether exception be thrown (no overwritten) when target file does exist, 
    BOOST_CHECK_EQUAL(fc::exists(tgt_dir + "/" + test_file_name), true);
    BOOST_CHECK_EXCEPTION(fc::copy(src_dir + "/" + test_file_name, tgt_dir + "/" + test_file_name), 
                          fc::exception,  


### PR DESCRIPTION
boost 74 has breaking change from 73 in file copy. the default behavior is changed, meaning 74 is recursive copy, but 73 is not.
According to the ruling in EPE-487, 
"Make the changes required in FC to properly handle all versions of boost so far.  This would mean leaving it as is for anything under Boost 1.74 and creating a comparable solution for versions greater than 1.73.  This could be achieved by using Boost’s version macros that it supplies."

Fix is verified on my local env with boost 74, and asking customer to verify also.

From boost 74 release (thanks Matt to bring it up)
New, breaking change: copy operation has been extended and reworked to implement behavior specified in C++20 [fs.op.copy]. This includes support for copy_options::recursive, copy_options::copy_symlinks, copy_options::skip_symlinks, copy_options::directories_only, copy_options::create_symlinks and copy_options::create_hard_links options. The operation performs additional checks based on the specified options. Applying copy to a directory with default copy_options will now also copy files residing in that directory (but not nested directories or files in those directories).