### PR TITLE
Inhibit various compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,10 @@ elseif(NOT CMAKE_CXX_STANDARD)
    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
+# Suppress warnings on 3rdParty Library
+add_definitions( -w )
 add_subdirectory( secp256k1 )
+remove_definitions( -w )
 
 IF( ECC_IMPL STREQUAL openssl )
   SET( ECC_REST src/crypto/elliptic_impl_pub.cpp )

--- a/src/crypto/crc.cpp
+++ b/src/crypto/crc.cpp
@@ -515,6 +515,9 @@ uint32_t crc32cSlicingBy8(uint32_t crc, const void* data, size_t length) {
 
 #define CRC32C_POLY 0x1EDC6F41
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-const-variable"
+
 #define CRC32C(c,d) (c=(c>>8)^crc_c[(c^(d))&0xFF])
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /* Copyright 2001, D. Otis.  Use this program, code or tables    */
@@ -601,6 +604,9 @@ static const uint32_t crc_c[256] = {
          0x79B737BA, 0x8BDCB4B9, 0x988C474D, 0x6AE7C44E,
          0xBE2DA0A5, 0x4C4623A6, 0x5F16D052, 0xAD7D5351,
  };
+ 
+#pragma GCC diagnostic pop
+
 #if !defined __SSE4_2__ || (defined __SSE4_2__ && !defined __x86_64__)
 
 


### PR DESCRIPTION
The secp256k1 produces compiler warning when built using clang.  Since this is a 3rdParty library that doesn't appear to be maintained by block.one, I decided to inhibit all compiler warnings when building secp256k1.

When building fc, -Wunused-const-variable warning was raised.  As I couldn't deduce if that is truly the case, I decided to also inhibit that warning when compiler the offending variable.