### PR TITLE
Huangminghuang/fix datastream<cfile>

### DIFF
--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -179,6 +179,11 @@ inline cfile_datastream cfile::create_datastream() {
    return cfile_datastream(*this);
 }
 
+/*
+ *  @brief datastream adapter that adapts cfile for use with fc pack
+ *
+ *  This class supports pack functionality but not unpack.
+ */
 template <>
 class datastream<fc::cfile, void> : public fc::cfile {
  public:
@@ -190,8 +195,6 @@ class datastream<fc::cfile, void> : public fc::cfile {
       c = this->getc();
       return true;
    }
-
-   bool remaining() { return !this->eof(); }
 
    fc::cfile&       storage() { return *this; }
    const fc::cfile& storage() const { return *this; }

--- a/include/fc/io/cfile.hpp
+++ b/include/fc/io/cfile.hpp
@@ -30,11 +30,11 @@ public:
      : _file(nullptr, &fclose)
    {}
 
-   void set_file_path( const fc::path& file_path ) {
-      _file_path = file_path;
+   void set_file_path( fc::path file_path ) {
+      _file_path = std::move( file_path );
    }
 
-   const fc::path& get_file_path() const {
+   fc::path get_file_path() const {
       return _file_path;
    }
 
@@ -53,29 +53,10 @@ public:
       if( !_file ) {
          throw std::ios_base::failure( "cfile unable to open: " +  _file_path.generic_string() + " in mode: " + std::string( mode ) );
       }
-
-
       _open = true;
    }
 
-   bool remaining(){
-      if(!is_open() || eof())
-         return false;
-
-      int c = getc();
-      bool isEOF = eof();
-      int result = ungetc(c, _file.get());
-      if(EOF == result)
-         throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
-                                       " unable to ungetc" );
-
-      return isEOF;
-   }
-
    size_t tellp() const {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       long result = ftell( _file.get() );
       if (result == -1)
          throw std::ios_base::failure("cfile: " + get_file_path().generic_string() +
@@ -91,9 +72,6 @@ public:
    }
 
    void seek_end( long loc ) {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       if( 0 != fseek( _file.get(), loc, SEEK_END ) ) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to SEEK_END to: " + std::to_string(loc) );
@@ -101,9 +79,6 @@ public:
    }
 
    void skip( long loc) {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       if( 0 != fseek( _file.get(), loc, SEEK_CUR ) ) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to SEEK_CUR to: " + std::to_string(loc) );
@@ -111,9 +86,6 @@ public:
    }
 
    void read( char* d, size_t n ) {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       size_t result = fread( d, 1, n, _file.get() );
       if( result != n ) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
@@ -122,9 +94,6 @@ public:
    }
 
    void write( const char* d, size_t n ) {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       size_t result = fwrite( d, 1, n, _file.get() );
       if( result != n ) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
@@ -133,9 +102,6 @@ public:
    }
 
    void flush() {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       if( 0 != fflush( _file.get() ) ) {
          int ec = ferror( _file.get() );
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
@@ -144,9 +110,6 @@ public:
    }
 
    void sync() {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
       const int fd = fileno(_file.get() );
       if( -1 == fd ) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
@@ -159,18 +122,10 @@ public:
       }
    }
 
-   bool eof() const {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
+   bool eof() const { return feof(_file.get()) != 0; }
 
-      return feof(_file.get()) != 0;
-   }
-
-   int getc() {
-      if(!is_open())
-         throw std::ios_base::failure("cfile is not open");
-
-      int ret = fgetc(_file.get());
+   int getc() { 
+      int ret = fgetc(_file.get());  
       if (ret == EOF) {
          throw std::ios_base::failure( "cfile: " + _file_path.generic_string() +
                                        " unable to read 1 byte");
@@ -186,11 +141,6 @@ public:
    cfile_datastream create_datastream();
 
 private:
-   cfile(const cfile &) = delete;
-   cfile(cfile &&) = delete;
-   const cfile& operator=(const cfile &) = delete;
-   cfile& operator=(cfile &&) = delete;
-
    bool                  _open = false;
    fc::path              _file_path;
    detail::unique_file   _file;
@@ -221,12 +171,7 @@ public:
 
    size_t tellp() const { return cf.tellp(); }
 
-private:
-   cfile_datastream(const cfile_datastream &) = delete;
-   cfile_datastream(cfile_datastream &&) = delete;
-   const cfile_datastream& operator=(const cfile_datastream &) = delete;
-   cfile_datastream& operator=(cfile_datastream &&) = delete;
-
+ private:
    cfile& cf;
 };
 
@@ -246,13 +191,10 @@ class datastream<fc::cfile, void> : public fc::cfile {
       return true;
    }
 
+   bool remaining() { return !this->eof(); }
+
    fc::cfile&       storage() { return *this; }
    const fc::cfile& storage() const { return *this; }
-private:
-   datastream(const datastream &) = delete;
-   datastream(datastream &&) = delete;
-   const datastream& operator=(const datastream &) = delete;
-   datastream& operator=(datastream &&) = delete;
 };
 
 

--- a/test/io/test_cfile.cpp
+++ b/test/io/test_cfile.cpp
@@ -1,6 +1,5 @@
 #define BOOST_TEST_MODULE io
 #include <boost/test/included/unit_test.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <fc/io/cfile.hpp>
 
@@ -57,46 +56,6 @@ BOOST_AUTO_TEST_SUITE(cfile_test_suite)
       t.close();
       fc::remove_all( t.get_file_path() );
       BOOST_CHECK( !fc::exists( tempdir.path() / "test") );
-   }
-
-   BOOST_AUTO_TEST_CASE(test_eof)
-   {
-      fc::temp_file tmpfile;
-      {
-         boost::filesystem::ofstream ofs(tmpfile.path());
-         ofs << "the quick brown fox";
-      }
-
-      cfile t;
-      t.set_file_path(tmpfile.path());
-      BOOST_CHECK_NO_THROW(t.open("r"));
-      BOOST_CHECK(t.is_open());
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_NO_THROW(t.getc() == 't');
-      BOOST_CHECK_NO_THROW(t.skip(10));
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_NO_THROW(t.getc() == 'r');
-      BOOST_CHECK_NO_THROW(t.skip(7));
-      BOOST_CHECK_NO_THROW(t.eof());
-      BOOST_CHECK_THROW(t.getc(), std::ios_base::failure);
-
-      BOOST_CHECK_NO_THROW(t.open("r"));
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_NO_THROW(t.skip(30));
-      BOOST_CHECK_NO_THROW(t.eof());
-
-      BOOST_CHECK_NO_THROW(t.open("r"));
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_THROW(t.skip(-2), std::ios_base::failure);
-
-      BOOST_CHECK_NO_THROW(t.open("r"));
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_NO_THROW(t.skip(4));
-      BOOST_CHECK_NO_THROW(!t.eof());
-      BOOST_CHECK_NO_THROW(t.getc() == 'q');
-      BOOST_CHECK_NO_THROW(t.skip(19));
-      BOOST_CHECK_NO_THROW(t.eof());
-      BOOST_CHECK_THROW(t.seek(25), std::ios_base::failure);
    }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR reverts the changes made by PR 184, and remove `datastream<cfile>::remaining()` so that it cannot be used for `fc::raw::unpack()`. 

The design of  `datastream<cfile>` is meant to be used for `fc::pack()` only; therefore, it shouldn't be used  for calling `datastream<cfile>::remaining()` right after `datastream<cfile>::skip()`.  For `fc::unpack()` usage, choose `cfile_datastream`  instead.