### PR TITLE
remvove uneeded Boost_LIBRARIES linkage from webauthn test

### DIFF
--- a/test/crypto/CMakeLists.txt
+++ b/test/crypto/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable( test_cypher_suites test_cypher_suites.cpp )
 target_link_libraries( test_cypher_suites fc )
 
 add_executable( test_webauthn test_webauthn.cpp )
-target_link_libraries( test_webauthn fc ${Boost_LIBRARIES})
+target_link_libraries( test_webauthn fc )
 
 add_test(NAME test_cypher_suites COMMAND libraries/fc/test/crypto/test_cypher_suites WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 add_test(NAME test_webauthn COMMAND libraries/fc/test/crypto/test_webauthn WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
This isn't needed since the test uses the include-only variant of boost unit test. Actually, in some environments this mistake ends up causing a build failure.