### PR TITLE
implement zipkin nested span - 2.1.x

### DIFF
--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -22,6 +22,16 @@ inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* tr
               : ::std::optional<::fc::zipkin_span>{};
 }
 
+/// @param condition create the trace only when the condition is true
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
+/// @return implementation defined type RAII object that submits trace on exit of scope
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id_if(bool condition, const char* trace_str, const fc::sha256& trace_id) {
+   return (condition && ::fc::zipkin_config::is_enabled())
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), ::fc::zipkin_span::to_id(trace_id) , 0)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
 inline ::std::optional<::fc::zipkin_span> fc_create_span_with_id(const char* span_str, uint64_t id, const fc::sha256& trace_id) {
    auto tid = ::fc::zipkin_span::to_id(trace_id);
    return ::fc::zipkin_config::is_enabled()

--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -9,7 +9,7 @@
 inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str) {
    return ::fc::zipkin_config::is_enabled()
               ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_config::get_next_unique_id(),
-                                                   (trace_str))
+                                                   (trace_str), 0, 0)
               : ::std::optional<::fc::zipkin_span>{};
 }
 
@@ -18,7 +18,7 @@ inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str)
 /// @return implementation defined type RAII object that submits trace on exit of scope
 inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* trace_str, const fc::sha256& trace_id) {
    return ::fc::zipkin_config::is_enabled()
-              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str))
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), 0 , 0)
               : ::std::optional<::fc::zipkin_span>{};
 }
 

--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -1,44 +1,75 @@
 #pragma once
 
 #include <fc/log/zipkin.hpp>
+#include <fc/log/logger.hpp>
 #include <optional>
 
-/// @param TRACE_STR const char* identifier for trace
+/// @param trace_str const char* identifier for trace
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace( TRACE_STR ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_config::get_next_unique_id(),
+                                                   (trace_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_STR const char* identifier for trace
-/// @param TRACE_ID fc::sha256 id to use
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace_with_id( TRACE_STR, TRACE_ID ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, ::fc::zipkin_span::to_id(TRACE_ID), (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* trace_str, const fc::sha256& trace_id) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_VARNAME variable returned from fc_create_trace
-/// @param SPAN_STR const char* indentifier
+inline ::std::optional<::fc::zipkin_span> fc_create_span_with_id(const char* span_str, uint64_t id, const fc::sha256& trace_id) {
+   auto tid = ::fc::zipkin_span::to_id(trace_id);
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, id, span_str, tid, tid)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_start_time(const char* trace_str, fc::time_point start) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, trace_str, start)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+/// @param trace variable returned from fc_create_trace
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span( TRACE_VARNAME, SPAN_STR ) \
-      ( (TRACE_VARNAME) && ::fc::zipkin_config::is_enabled() ) ? \
-        (TRACE_VARNAME).opt->create_span( (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span(const ::std::optional<::fc::zipkin_span>& trace,
+                                                         const char*                               span_str) {
+   return ((trace) && ::fc::zipkin_config::is_enabled()) ? (trace)->create_span((span_str))
+                                                         : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_TOKEN variable returned from trace.get_token()
-/// @param SPAN_STR const char* indentifier
+/// @param trace_token variable returned from trace.get_token()
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span_from_token( TRACE_TOKEN, SPAN_STR ) \
-      ( (TRACE_TOKEN) && ::fc::zipkin_config::is_enabled() ) ? \
-        ::fc::zipkin_trace::create_span_from_token( (TRACE_TOKEN), (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span_from_token(fc::zipkin_span::token trace_token,
+                                                                    const char*            span_str) {
+   return ((trace_token) && ::fc::zipkin_config::is_enabled())
+              ? ::fc::zipkin_span::create_span_from_token((trace_token), (span_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param SPAN_VARNAME variable returned from fc_create_span
-/// @param TAG_KEY_STR string key
-/// @param TAG_VALUE string value
-#define fc_add_tag( SPAN_VARNAME, TAG_KEY_STR, TAG_VALUE_STR) \
+/// @param span variable returned from fc_create_span
+/// @param tag_key_str string key
+/// @param tag_value string value
+template <typename Value>
+inline void fc_add_tag(::std::optional<::fc::zipkin_span>& span, const char* tag_key_str, Value&& value) {
+   if ((span) && ::fc::zipkin_config::is_enabled())
+      (span)->add_tag((tag_key_str), std::forward<Value>(value));
+}
+
+inline fc::zipkin_span::token fc_get_token(const ::std::optional<::fc::zipkin_span>& span) {
+   return (span && ::fc::zipkin_config::is_enabled()) ? span->get_token() : fc::zipkin_span::token(0, 0);
+}
+
+
+#define fc_trace_log( TRACE_OR_SPAN, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
-      if( (SPAN_VARNAME) && ::fc::zipkin_config::is_enabled() ) \
-         (SPAN_VARNAME)->add_tag( (TAG_KEY_STR), (TAG_VALUE_STR) ); \
+   if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::info ) ) \
+      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( info, FORMAT " traceID=${_the_trace_id_}", ("_the_trace_id_", TRACE_OR_SPAN->trace_id_string()) __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -58,11 +58,14 @@ private:
 };
 
 struct zipkin_span {
-   explicit zipkin_span( std::string name, uint64_t parent_id = 0 )
-         : data( std::move( name ), parent_id ) {}
+   explicit zipkin_span( std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+         : data( std::move( name ), trace_id, parent_id ) {}
 
-   explicit zipkin_span( uint64_t id, std::string name, uint64_t parent_id = 0 )
-         : data( id, std::move( name ), parent_id ) {}
+   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+         : data( id, std::move( name ), trace_id, parent_id ) {}
+
+   explicit zipkin_span( std::string name, fc::time_point start )
+         : data( std::move( name ), start ) {}
 
    zipkin_span( const zipkin_span& ) = delete;
    zipkin_span& operator=( const zipkin_span& ) = delete;
@@ -107,29 +110,28 @@ struct zipkin_span {
       friend struct zipkin_trace;
       friend struct optional_trace;
       constexpr explicit operator bool() const noexcept { return id != 0; }
+      token( uint64_t id, uint64_t trace_id )
+            : id( id ), trace_id( trace_id ) {}
    private:
-      explicit token( uint64_t id )
-            : id( id ) {}
       uint64_t id;
+      uint64_t trace_id;
    };
 
-   token get_token() const { return token{data.id}; };
+   token get_token() const { return token{data.id, data.trace_id }; };
 
    static uint64_t to_id( const fc::sha256& id );
 
-   template<typename T>
-   static uint64_t to_id( const T& id ) {
-      static_assert( std::is_same_v<decltype( id.data() ), const uint64_t*>, "expected uint64_t" );
-      return id.data()[3];
-   }
-
    struct span_data {
-      explicit span_data( std::string name, uint64_t parent_id = 0 )
-            : id( zipkin_config::get_next_unique_id() ), parent_id( parent_id ),
+      explicit span_data( std::string name, uint64_t trace_id, uint64_t parent_id )
+            : id( zipkin_config::get_next_unique_id() ), trace_id( trace_id ), parent_id( parent_id ),
               start( time_point::now() ), name( std::move( name ) ) {}
 
-      explicit span_data( uint64_t id, std::string name, uint64_t parent_id = 0 )
-            : id( id ), parent_id( parent_id ), start( time_point::now() ), name( std::move( name ) ) {}
+      explicit span_data( uint64_t id, std::string name, uint64_t trace_id, uint64_t parent_id )
+            : id( id ), trace_id( trace_id == 0 ? id : trace_id ), parent_id( parent_id ), start( time_point::now() ), name( std::move( name ) ) {}
+
+      explicit span_data( std::string name, fc::time_point start) 
+         : id( zipkin_config::get_next_unique_id() ), trace_id( zipkin_config::get_next_unique_id() ), parent_id( 0 ),
+              start( start), name( std::move( name ) ) {}
 
       span_data( const span_data& ) = delete;
       span_data& operator=( const span_data& ) = delete;
@@ -137,39 +139,26 @@ struct zipkin_span {
       span_data( span_data&& rhs ) = default;
 
       uint64_t id;
-      // zipkin traceId and parentId are same (when parent_id set) since only allowing trace with span children.
-      // Not currently supporting spans with children, only trace with children spans.
-      const uint64_t parent_id;
-      const fc::time_point start;
+      const uint64_t             trace_id;
+      const uint64_t             parent_id;
+      const fc::time_point       start;
       fc::time_point stop;
       std::string name;
       fc::mutable_variant_object tags;
    };
 
-   span_data data;
-};
-
-struct zipkin_trace : public zipkin_span {
-   using zipkin_span::zipkin_span;
-
    [[nodiscard]] std::optional<zipkin_span> create_span( std::string name ) const {
-      return zipkin_span{std::move( name ), get_token().id};
+      return create_span_from_token(get_token(), std::move(name));
    }
 
    [[nodiscard]] static std::optional<zipkin_span>
    create_span_from_token( zipkin_span::token token, std::string name ) {
-      return zipkin_span{std::move( name ), token.id};
+      return zipkin_span{std::move( name ), token.trace_id, token.id};
    }
-};
 
-struct optional_trace {
-   std::optional<zipkin_trace> opt;
+   std::string trace_id_string() const;
 
-   constexpr explicit operator bool() const noexcept { return opt.has_value(); }
-
-   [[nodiscard]] zipkin_span::token get_token() const {
-      return opt ? opt->get_token() : zipkin_span::token( 0 );
-   }
+   span_data data;
 };
 
 class zipkin {

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -58,10 +58,10 @@ private:
 };
 
 struct zipkin_span {
-   explicit zipkin_span( std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+   explicit zipkin_span( std::string name, uint64_t trace_id, uint64_t parent_id )
          : data( std::move( name ), trace_id, parent_id ) {}
 
-   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id, uint64_t parent_id )
          : data( id, std::move( name ), trace_id, parent_id ) {}
 
    explicit zipkin_span( std::string name, fc::time_point start )

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -32,7 +32,7 @@ public:
    /// @param url the url endpoint of zipkin server. e.g. http://127.0.0.1:9411/api/v2/spans
    /// @param service_name the service name to include in each zipkin span
    /// @param timeout_us the timeout in microseconds for each http call (9 consecutive failures and zipkin is disabled)
-   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us );
+   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t wait_time_seconds = 0);
 
    /// Thread safe only if init() called from main thread before spawning of any threads
    /// @throw assert_exception if called before init()
@@ -163,7 +163,7 @@ struct zipkin_span {
 
 class zipkin {
 public:
-   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us );
+   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t wait_time_seconds );
 
    /// finishes logging all queued up spans
    ~zipkin() = default;

--- a/include/fc/network/http/http_client.hpp
+++ b/include/fc/network/http/http_client.hpp
@@ -32,7 +32,7 @@ class http_client {
                     json::output_formatting::stringify_large_ints_and_doubles) {
         variant payload_v;
         to_variant(payload, payload_v);
-        return post_sync(dest, payload_v, deadline);
+        return post_sync(dest, payload_v, deadline, formatting);
       }
 
       void add_cert(const std::string& cert_pem_string);

--- a/include/fc/network/http/http_client.hpp
+++ b/include/fc/network/http/http_client.hpp
@@ -9,6 +9,7 @@
 #include <fc/variant.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/network/url.hpp>
+#include <fc/io/json.hpp>
 
 namespace fc {
 
@@ -17,13 +18,21 @@ class http_client {
       http_client();
       ~http_client();
 
-      variant post_sync(const url& dest, const variant& payload, const time_point& deadline = time_point::maximum());
+      variant
+      post_sync(const url &dest, const variant &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles);
 
-      template<typename T>
-      variant post_sync(const url& dest, const T& payload, const time_point& deadline = time_point::maximum()) {
-         variant payload_v;
-         to_variant(payload, payload_v);
-         return post_sync(dest, payload_v, deadline);
+      template <typename T>
+      variant
+      post_sync(const url &dest, const T &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles) {
+        variant payload_v;
+        to_variant(payload, payload_v);
+        return post_sync(dest, payload_v, deadline);
       }
 
       void add_cert(const std::string& cert_pem_string);

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -18,7 +18,7 @@ struct local_endpoint_resolver {
    using tcp        = boost::asio::ip::tcp;
    using error_code = boost::system::error_code;
 
-   local_endpoint_resolver(boost::asio::io_context& ctx)
+   local_endpoint_resolver()
        : resolver(ctx)
        , sock(ctx)
        , timer(ctx) {}

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -44,8 +44,7 @@ struct local_endpoint_resolver {
         sock, endpoints,
         [this](const error_code &ec, const tcp::endpoint &endpoint) {
           if (ec) {
-            std::cout << "failed to connect to " << remote
-                      << ", retry in 5 seconds\n";
+            wlog("failed to connect to ${remote}, retry in 5 seconds", ("remote", remote));
             timer.expires_from_now(boost::posix_time::seconds(5));
             timer.async_wait([this](const error_code &ec) {
               if (!ec)

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -314,7 +314,7 @@ public:
       const deadline_type&               deadline;
    };
 
-variant
+   variant
    post_sync(const url &dest, const variant &payload,
              const fc::time_point &_deadline,
              json::output_formatting formatting) {
@@ -453,13 +453,16 @@ http_client::http_client()
 
 }
 
-variant http_client::post_sync(const url& dest, const variant& payload, const fc::time_point& deadline) {
+variant http_client::post_sync(const url &dest, const variant &payload,
+                               const fc::time_point &deadline,
+                               json::output_formatting formatting) {
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-   if(dest.proto() == "unix")
-      return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline);
-   else
+  if (dest.proto() == "unix")
+    return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline,
+                          formatting);
 #endif
-      return _my->post_sync(dest, payload, deadline);
+  else
+    return _my->post_sync(dest, payload, deadline, formatting);
 }
 
 void http_client::add_cert(const std::string& cert_pem_string) {

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -314,7 +314,10 @@ public:
       const deadline_type&               deadline;
    };
 
-   variant post_sync(const url& dest, const variant& payload, const fc::time_point& _deadline) {
+variant
+   post_sync(const url &dest, const variant &payload,
+             const fc::time_point &_deadline,
+             json::output_formatting formatting) {
       static const deadline_type epoch(boost::gregorian::date(1970, 1, 1));
       auto deadline = epoch + boost::posix_time::microseconds(_deadline.time_since_epoch().count());
       FC_ASSERT(dest.host(), "No host set on URL");
@@ -338,7 +341,7 @@ public:
       req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
       req.set(http::field::content_type, "application/json");
       req.keep_alive(true);
-      req.body() = json::to_string(payload, _deadline);
+      req.body() = json::to_string(payload, _deadline, formatting);
       req.prepare_payload();
 
       auto conn_iter = get_connection(dest, deadline);
@@ -393,6 +396,8 @@ public:
          }
       } else if (res.result() == http::status::not_found) {
          FC_THROW("URL not found: ${url}", ("url", (std::string)dest));
+      } else if (res.result() == http::status::bad_request) {
+         FC_THROW("Received request: ${msg}", ("msg", res.body()));
       }
 
       return result;


### PR DESCRIPTION
The PR implement the functionality to create nested zipkin spans  and some other improvements:
  -  change macros to inline functions
  - add warning messages to indicate why spans are no longer sending to the zipkin collector 
  - add create_trace_with_start_time for tracking some async operations
  - use lagacy format for json encoding to be able to interoperate with Jaeger collector
  - add fc_trace_log to correlate zipkin traces with log messages. 