### PR TITLE
Update Zipkin connection retry

### DIFF
--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -45,6 +45,11 @@ public:
    /// Starts with a random id and increments on each call, will not return 0
    static uint64_t get_next_unique_id();
 
+   /// Handle SIGHUP signal
+   static void handle_sighup();
+   static void reset_sighup();
+   static bool check_sighup();
+
 private:
    /// Provide access to initialized zipkin endpoint
    /// Thread safe as long as init() called correctly
@@ -55,6 +60,7 @@ private:
 
 private:
    std::unique_ptr<zipkin> zip;
+   static bool received_sighup;
 };
 
 struct zipkin_span {

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -32,7 +32,8 @@ public:
    /// @param url the url endpoint of zipkin server. e.g. http://127.0.0.1:9411/api/v2/spans
    /// @param service_name the service name to include in each zipkin span
    /// @param timeout_us the timeout in microseconds for each http call (9 consecutive failures and zipkin is disabled)
-   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us );
+   /// @param retry_interval_us the interval in microseconds for connecting to zipkin
+   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us );
 
    /// Thread safe only if init() called from main thread before spawning of any threads
    /// @throw assert_exception if called before init()
@@ -177,7 +178,7 @@ struct optional_trace {
 
 class zipkin {
 public:
-   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us );
+   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us );
 
    /// finishes logging all queued up spans
    ~zipkin() = default;

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -45,7 +45,7 @@ public:
    /// Starts with a random id and increments on each call, will not return 0
    static uint64_t get_next_unique_id();
 
-   /// Handle SIGHUP signal forwarded from net_plugin
+   /// Handle SIGHUP signal
    static void handle_sighup();
 
 private:
@@ -191,10 +191,12 @@ public:
    // Logs zipkin json via http on separate thread
    void log( zipkin_span::span_data&& span );
 
+   /// thread safe
    void on_sighup_flag();
    void off_sighup_flag();
-   bool is_sighup_flag_on() const { return sighup_flag; };
+   bool is_sighup_flag_on() const;
 
+   void post_request(zipkin_span::span_data&& span);
 private:
    class impl;
    std::unique_ptr<impl> my;

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -45,7 +45,8 @@ public:
    /// Starts with a random id and increments on each call, will not return 0
    static uint64_t get_next_unique_id();
 
-   /// Handle SIGHUP signal
+   /// Signal safe
+   /// This is not called directly from the SIGHUP signal handler in the main thread
    static void handle_sighup();
 
 private:
@@ -191,16 +192,12 @@ public:
    // Logs zipkin json via http on separate thread
    void log( zipkin_span::span_data&& span );
 
-   /// thread safe
-   void on_sighup_flag();
-   void off_sighup_flag();
-   bool is_sighup_flag_on() const;
-
+   // Post http request to the boost asio queue
    void post_request(zipkin_span::span_data&& span);
+
 private:
    class impl;
    std::unique_ptr<impl> my;
-   bool sighup_flag;
 };
 
 } // namespace fc

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -46,7 +46,6 @@ public:
    static uint64_t get_next_unique_id();
 
    /// Signal safe
-   /// This is not called directly from the SIGHUP signal handler
    static void handle_sighup();
 
 private:

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -46,7 +46,7 @@ public:
    static uint64_t get_next_unique_id();
 
    /// Signal safe
-   /// This is not called directly from the SIGHUP signal handler in the main thread
+   /// This is not called directly from the SIGHUP signal handler
    static void handle_sighup();
 
 private:

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -45,10 +45,8 @@ public:
    /// Starts with a random id and increments on each call, will not return 0
    static uint64_t get_next_unique_id();
 
-   /// Handle SIGHUP signal
+   /// Handle SIGHUP signal forwarded from net_plugin
    static void handle_sighup();
-   static void reset_sighup();
-   static bool check_sighup();
 
 private:
    /// Provide access to initialized zipkin endpoint
@@ -60,7 +58,6 @@ private:
 
 private:
    std::unique_ptr<zipkin> zip;
-   static bool received_sighup;
 };
 
 struct zipkin_span {
@@ -194,9 +191,14 @@ public:
    // Logs zipkin json via http on separate thread
    void log( zipkin_span::span_data&& span );
 
+   void on_sighup_flag();
+   void off_sighup_flag();
+   bool is_sighup_flag_on() const { return sighup_flag; };
+
 private:
    class impl;
    std::unique_ptr<impl> my;
+   bool sighup_flag;
 };
 
 } // namespace fc

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -31,7 +31,8 @@ public:
    /// Not thread safe, call from main thread before spawning any threads that might use zipkin.
    /// @param url the url endpoint of zipkin server. e.g. http://127.0.0.1:9411/api/v2/spans
    /// @param service_name the service name to include in each zipkin span
-   /// @param timeout_us the timeout in microseconds for each http call (9 consecutive failures and zipkin is disabled)
+   /// @param timeout_us the timeout in microseconds for each http call
+   ///        (9 consecutive failures and zipkin is disabled, SIGHUP will reset the failure counter and re-enable zipkin)
    /// @param retry_interval_us the interval in microseconds for connecting to zipkin
    static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us );
 

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -64,7 +64,8 @@ public:
    uint64_t next_id = 0;
    http_client http;
    bool connected = false;
-   bool timer_expired = true;
+   // thread safe
+   std::atomic<bool> timer_expired = true;
    std::atomic<uint32_t> consecutive_errors = 0;
    std::atomic<unsigned char> stopped = 0;
    std::optional<url> endpoint;

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -200,9 +200,9 @@ void zipkin::log( zipkin_span::span_data&& span ) {
       if( my->timer_expired ) {
          my->timer_expired = false;
          my->timer.expires_from_now(boost::posix_time::seconds(30));
-         my->timer.async_wait([this, span{std::move(span)}](auto&) {
+         my->timer.async_wait([this, span{std::move(span)}](auto&) mutable {
             ilog("Retry connecting to zipkin: ${u} ...", ("u", my->zipkin_url) );
-            post_request(const_cast<zipkin_span::span_data&&>(span));
+            post_request(std::move(span));
             my->timer_expired = true;
          });
       }

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -12,8 +12,6 @@
 #include <thread>
 #include <random>
 
-#include <csignal>
-
 namespace fc {
 
 zipkin_config& zipkin_config::get() {
@@ -195,6 +193,7 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
    }
    ++consecutive_errors;
    connected = false;
+   sleep(30);
 }
 
 uint64_t zipkin_span::to_id( const fc::sha256& id ) {

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -178,7 +178,7 @@ void zipkin::log( zipkin_span::span_data&& span ) {
    if( my->stopped ) {
       return;
    }else if( fc::do_sighup && fc::sighup_requested.load()) {
-      do_sighup = 0;
+      fc::do_sighup = 0;
       fc::sighup_requested = false;
       my->consecutive_errors = 0;
    }else if( my->consecutive_errors > my->max_consecutive_errors ) {

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -180,6 +180,10 @@ void zipkin::log( zipkin_span::span_data&& span ) {
       return;
    }
 
+   if (my->consecutive_errors > 0){
+      sleep(30);
+   }
+
    boost::asio::post(my->work_strand, [this, span{std::move(span)}]() mutable {
       my->log( std::move( span ) );
    });
@@ -213,7 +217,6 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
    }
    ++consecutive_errors;
    connected = false;
-   sleep(30);
 }
 
 uint64_t zipkin_span::to_id( const fc::sha256& id ) {

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -14,10 +14,8 @@
 
 namespace fc {
 
-//signal safe
-volatile sig_atomic_t do_sighup = 0;
-//thread safe
-std::atomic<bool> sighup_requested = false;
+// signal safe, thread atomic and lock free
+std::atomic_flag do_sighup = ATOMIC_FLAG_INIT;
 
 zipkin_config& zipkin_config::get() {
    static zipkin_config the_one;
@@ -49,8 +47,7 @@ uint64_t zipkin_config::get_next_unique_id() {
 }
 
 void zipkin_config::handle_sighup(){
-    fc::do_sighup = 1;
-    fc::sighup_requested = true;
+    fc::do_sighup.test_and_set();
 }
 
 class zipkin::impl {
@@ -178,13 +175,15 @@ void zipkin::post_request(zipkin_span::span_data&& span) {
 void zipkin::log( zipkin_span::span_data&& span ) {
    if( my->stopped ) {
       return;
-   }else if( fc::do_sighup && fc::sighup_requested.load()) {
-      fc::do_sighup = 0;
-      fc::sighup_requested = false;
+   }else if( fc::do_sighup.test_and_set()) { // member func .test() is not available until c++20.
+      fc::do_sighup.clear();
       my->consecutive_errors = 0;
    }else if( my->consecutive_errors > my->max_consecutive_errors ) {
+      fc::do_sighup.clear(); // reverse test_and_set()
       return;
    }
+
+   fc::do_sighup.clear(); // reverse test_and_set()
 
    if( my->consecutive_errors > 0 ) {
       if( my->timer_expired ) {

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -44,10 +44,9 @@ uint64_t zipkin_config::get_next_unique_id() {
 }
 
 void zipkin_config::handle_sighup(){
-    if( !get().zip ) {
-        FC_THROW_EXCEPTION(fc::assert_exception, "uninitialized zipkin");
+    if( get().zip ) {
+       get().zip->on_sighup_flag();
     }
-    get().zip->on_sighup_flag();
 }
 
 class zipkin::impl {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
[EPE-933](https://blockone.atlassian.net/browse/EPE-933) [GitHub:issue:[10255](https://github.com/EOSIO/eos/issues/10255)]

on networks like EOS Mainnet, 9 attempts is very small and useless for intermittent failures like running a zipkin upgrade.

For production use, need to work more like:

1. retry every 30 seconds
2. have health reporting as to if connected or not
3. process SIGHUP or similar to force re-connect
4. Further if `telemetry-url` is a DNS name that points to multiple A or AAAA records, nodeos should try all the addreses returned before giving up 


Notes:
- Existing code supports item 4 above. 


## Change Type
**Select *ONE*:**
- [ ] Documentation
<!-- checked [x] = Documentation; unchecked [ ] = no changes, ignore this section -->
- [ ] Stability bug fix
<!-- checked [x] = Stability bug fix; unchecked [ ] = no changes, ignore this section -->
- [x] Other
<!-- checked [x] = Other; unchecked [ ] = no changes, ignore this section -->
- [ ] Other - special case
<!-- checked [x] = Other - special case; unchecked [ ] = no changes, ignore this section -->
<!-- Other - special case is for when a change warrants additional explanation or description in the release notes. Please include a description of the change for inclusion in the release notes. -->


## Testing Changes
**Select *ANY* that apply:**
- [ ] New Tests
<!-- checked [x] = new test cases were added; unchecked [ ] = no new test cases -->
- [ ] Existing Tests
<!-- checked [x] = existing test cases were edited; unchecked [ ] = no existing tests were modified -->
- [ ] Test Framework
<!-- checked [x] = this modifies the test framework; unchecked [ ] = no test framework changes -->
- [ ] CI System
<!-- checked [x] = this changes the CI system; unchecked [ ] = no CI changes -->
- [ ] Other
<!-- checked [x] = this integrates an external test system; unchecked [ ] = no miscellaneous test-related changes -->
<!-- Please describe your test changes, or list each new test and its purpose, under each respective checkbox -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
Method `handle_sighup() `defined in zipkin is to handle signal SIGHUP, and this method is not called directly from the original SIGHUP signal handler but from other handlers, e.g., `handle_sighup()` of `net_plugin`, one of the mandatory plugins, can be used to forward signal SIGHUP by calling zipkin's `handle_sighup()`.

Add a new option:
`telemetry-retry-interval-us`, optional parameter, specifies the retry interval for connecting to zipkin with default value set to 30000000.
