### PR TITLE
Huangminghuang/zipkin improvement boxed

### DIFF
--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -22,6 +22,16 @@ inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* tr
               : ::std::optional<::fc::zipkin_span>{};
 }
 
+/// @param condition create the trace only when the condition is true
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
+/// @return implementation defined type RAII object that submits trace on exit of scope
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id_if(bool condition, const char* trace_str, const fc::sha256& trace_id) {
+   return (condition && ::fc::zipkin_config::is_enabled())
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), ::fc::zipkin_span::to_id(trace_id) , 0)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
 inline ::std::optional<::fc::zipkin_span> fc_create_span_with_id(const char* span_str, uint64_t id, const fc::sha256& trace_id) {
    auto tid = ::fc::zipkin_span::to_id(trace_id);
    return ::fc::zipkin_config::is_enabled()

--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -9,7 +9,7 @@
 inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str) {
    return ::fc::zipkin_config::is_enabled()
               ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_config::get_next_unique_id(),
-                                                   (trace_str))
+                                                   (trace_str), 0, 0)
               : ::std::optional<::fc::zipkin_span>{};
 }
 
@@ -18,7 +18,7 @@ inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str)
 /// @return implementation defined type RAII object that submits trace on exit of scope
 inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* trace_str, const fc::sha256& trace_id) {
    return ::fc::zipkin_config::is_enabled()
-              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str))
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), 0 , 0)
               : ::std::optional<::fc::zipkin_span>{};
 }
 

--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -1,44 +1,75 @@
 #pragma once
 
 #include <fc/log/zipkin.hpp>
+#include <fc/log/logger.hpp>
 #include <optional>
 
-/// @param TRACE_STR const char* identifier for trace
+/// @param trace_str const char* identifier for trace
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace( TRACE_STR ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_config::get_next_unique_id(),
+                                                   (trace_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_STR const char* identifier for trace
-/// @param TRACE_ID fc::sha256 id to use
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace_with_id( TRACE_STR, TRACE_ID ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, ::fc::zipkin_span::to_id(TRACE_ID), (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* trace_str, const fc::sha256& trace_id) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_VARNAME variable returned from fc_create_trace
-/// @param SPAN_STR const char* indentifier
+inline ::std::optional<::fc::zipkin_span> fc_create_span_with_id(const char* span_str, uint64_t id, const fc::sha256& trace_id) {
+   auto tid = ::fc::zipkin_span::to_id(trace_id);
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, id, span_str, tid, tid)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_start_time(const char* trace_str, fc::time_point start) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, trace_str, start)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+/// @param trace variable returned from fc_create_trace
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span( TRACE_VARNAME, SPAN_STR ) \
-      ( (TRACE_VARNAME) && ::fc::zipkin_config::is_enabled() ) ? \
-        (TRACE_VARNAME).opt->create_span( (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span(const ::std::optional<::fc::zipkin_span>& trace,
+                                                         const char*                               span_str) {
+   return ((trace) && ::fc::zipkin_config::is_enabled()) ? (trace)->create_span((span_str))
+                                                         : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_TOKEN variable returned from trace.get_token()
-/// @param SPAN_STR const char* indentifier
+/// @param trace_token variable returned from trace.get_token()
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span_from_token( TRACE_TOKEN, SPAN_STR ) \
-      ( (TRACE_TOKEN) && ::fc::zipkin_config::is_enabled() ) ? \
-        ::fc::zipkin_trace::create_span_from_token( (TRACE_TOKEN), (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span_from_token(fc::zipkin_span::token trace_token,
+                                                                    const char*            span_str) {
+   return ((trace_token) && ::fc::zipkin_config::is_enabled())
+              ? ::fc::zipkin_span::create_span_from_token((trace_token), (span_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param SPAN_VARNAME variable returned from fc_create_span
-/// @param TAG_KEY_STR string key
-/// @param TAG_VALUE string value
-#define fc_add_tag( SPAN_VARNAME, TAG_KEY_STR, TAG_VALUE_STR) \
+/// @param span variable returned from fc_create_span
+/// @param tag_key_str string key
+/// @param tag_value string value
+template <typename Value>
+inline void fc_add_tag(::std::optional<::fc::zipkin_span>& span, const char* tag_key_str, Value&& value) {
+   if ((span) && ::fc::zipkin_config::is_enabled())
+      (span)->add_tag((tag_key_str), std::forward<Value>(value));
+}
+
+inline fc::zipkin_span::token fc_get_token(const ::std::optional<::fc::zipkin_span>& span) {
+   return (span && ::fc::zipkin_config::is_enabled()) ? span->get_token() : fc::zipkin_span::token(0, 0);
+}
+
+
+#define fc_trace_log( TRACE_OR_SPAN, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
-      if( (SPAN_VARNAME) && ::fc::zipkin_config::is_enabled() ) \
-         (SPAN_VARNAME)->add_tag( (TAG_KEY_STR), (TAG_VALUE_STR) ); \
+   if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::info ) ) \
+      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( info, FORMAT " traceID=${_the_trace_id_}", ("_the_trace_id_", TRACE_OR_SPAN->trace_id_string()) __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -63,11 +63,14 @@ private:
 };
 
 struct zipkin_span {
-   explicit zipkin_span( std::string name, uint64_t parent_id = 0 )
-         : data( std::move( name ), parent_id ) {}
+   explicit zipkin_span( std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+         : data( std::move( name ), trace_id, parent_id ) {}
 
-   explicit zipkin_span( uint64_t id, std::string name, uint64_t parent_id = 0 )
-         : data( id, std::move( name ), parent_id ) {}
+   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+         : data( id, std::move( name ), trace_id, parent_id ) {}
+
+   explicit zipkin_span( std::string name, fc::time_point start )
+         : data( std::move( name ), start ) {}
 
    zipkin_span( const zipkin_span& ) = delete;
    zipkin_span& operator=( const zipkin_span& ) = delete;
@@ -112,29 +115,28 @@ struct zipkin_span {
       friend struct zipkin_trace;
       friend struct optional_trace;
       constexpr explicit operator bool() const noexcept { return id != 0; }
+      token( uint64_t id, uint64_t trace_id )
+            : id( id ), trace_id( trace_id ) {}
    private:
-      explicit token( uint64_t id )
-            : id( id ) {}
       uint64_t id;
+      uint64_t trace_id;
    };
 
-   token get_token() const { return token{data.id}; };
+   token get_token() const { return token{data.id, data.trace_id }; };
 
    static uint64_t to_id( const fc::sha256& id );
 
-   template<typename T>
-   static uint64_t to_id( const T& id ) {
-      static_assert( std::is_same_v<decltype( id.data() ), const uint64_t*>, "expected uint64_t" );
-      return id.data()[3];
-   }
-
    struct span_data {
-      explicit span_data( std::string name, uint64_t parent_id = 0 )
-            : id( zipkin_config::get_next_unique_id() ), parent_id( parent_id ),
+      explicit span_data( std::string name, uint64_t trace_id, uint64_t parent_id )
+            : id( zipkin_config::get_next_unique_id() ), trace_id( trace_id ), parent_id( parent_id ),
               start( time_point::now() ), name( std::move( name ) ) {}
 
-      explicit span_data( uint64_t id, std::string name, uint64_t parent_id = 0 )
-            : id( id ), parent_id( parent_id ), start( time_point::now() ), name( std::move( name ) ) {}
+      explicit span_data( uint64_t id, std::string name, uint64_t trace_id, uint64_t parent_id )
+            : id( id ), trace_id( trace_id == 0 ? id : trace_id ), parent_id( parent_id ), start( time_point::now() ), name( std::move( name ) ) {}
+
+      explicit span_data( std::string name, fc::time_point start) 
+         : id( zipkin_config::get_next_unique_id() ), trace_id( zipkin_config::get_next_unique_id() ), parent_id( 0 ),
+              start( start), name( std::move( name ) ) {}
 
       span_data( const span_data& ) = delete;
       span_data& operator=( const span_data& ) = delete;
@@ -142,39 +144,26 @@ struct zipkin_span {
       span_data( span_data&& rhs ) = default;
 
       uint64_t id;
-      // zipkin traceId and parentId are same (when parent_id set) since only allowing trace with span children.
-      // Not currently supporting spans with children, only trace with children spans.
-      const uint64_t parent_id;
-      const fc::time_point start;
+      const uint64_t             trace_id;
+      const uint64_t             parent_id;
+      const fc::time_point       start;
       fc::time_point stop;
       std::string name;
       fc::mutable_variant_object tags;
    };
 
-   span_data data;
-};
-
-struct zipkin_trace : public zipkin_span {
-   using zipkin_span::zipkin_span;
-
    [[nodiscard]] std::optional<zipkin_span> create_span( std::string name ) const {
-      return zipkin_span{std::move( name ), get_token().id};
+      return create_span_from_token(get_token(), std::move(name));
    }
 
    [[nodiscard]] static std::optional<zipkin_span>
    create_span_from_token( zipkin_span::token token, std::string name ) {
-      return zipkin_span{std::move( name ), token.id};
+      return zipkin_span{std::move( name ), token.trace_id, token.id};
    }
-};
 
-struct optional_trace {
-   std::optional<zipkin_trace> opt;
+   std::string trace_id_string() const;
 
-   constexpr explicit operator bool() const noexcept { return opt.has_value(); }
-
-   [[nodiscard]] zipkin_span::token get_token() const {
-      return opt ? opt->get_token() : zipkin_span::token( 0 );
-   }
+   span_data data;
 };
 
 class zipkin {

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -34,7 +34,8 @@ public:
    /// @param timeout_us the timeout in microseconds for each http call
    ///        (9 consecutive failures and zipkin is disabled, SIGHUP will reset the failure counter and re-enable zipkin)
    /// @param retry_interval_us the interval in microseconds for connecting to zipkin
-   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us );
+   /// @param wait_time_seconds the initial wait time in seconds for connecting to zipkin, an exception is thrown when the connection is not established within the wait time. 
+   static void init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us, uint32_t wait_time_seconds = 0 );
 
    /// Thread safe only if init() called from main thread before spawning of any threads
    /// @throw assert_exception if called before init()
@@ -168,7 +169,7 @@ struct zipkin_span {
 
 class zipkin {
 public:
-   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us );
+   zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us , uint32_t wait_time_seconds );
 
    /// finishes logging all queued up spans
    ~zipkin() = default;

--- a/include/fc/log/zipkin.hpp
+++ b/include/fc/log/zipkin.hpp
@@ -63,10 +63,10 @@ private:
 };
 
 struct zipkin_span {
-   explicit zipkin_span( std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+   explicit zipkin_span( std::string name, uint64_t trace_id, uint64_t parent_id )
          : data( std::move( name ), trace_id, parent_id ) {}
 
-   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id = 0, uint64_t parent_id = 0 )
+   explicit zipkin_span( uint64_t id, std::string name, uint64_t trace_id, uint64_t parent_id )
          : data( id, std::move( name ), trace_id, parent_id ) {}
 
    explicit zipkin_span( std::string name, fc::time_point start )

--- a/include/fc/network/http/http_client.hpp
+++ b/include/fc/network/http/http_client.hpp
@@ -32,7 +32,7 @@ class http_client {
                     json::output_formatting::stringify_large_ints_and_doubles) {
         variant payload_v;
         to_variant(payload, payload_v);
-        return post_sync(dest, payload_v, deadline);
+        return post_sync(dest, payload_v, deadline, formatting);
       }
 
       void add_cert(const std::string& cert_pem_string);

--- a/include/fc/network/http/http_client.hpp
+++ b/include/fc/network/http/http_client.hpp
@@ -9,6 +9,7 @@
 #include <fc/variant.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/network/url.hpp>
+#include <fc/io/json.hpp>
 
 namespace fc {
 
@@ -17,13 +18,21 @@ class http_client {
       http_client();
       ~http_client();
 
-      variant post_sync(const url& dest, const variant& payload, const time_point& deadline = time_point::maximum());
+      variant
+      post_sync(const url &dest, const variant &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles);
 
-      template<typename T>
-      variant post_sync(const url& dest, const T& payload, const time_point& deadline = time_point::maximum()) {
-         variant payload_v;
-         to_variant(payload, payload_v);
-         return post_sync(dest, payload_v, deadline);
+      template <typename T>
+      variant
+      post_sync(const url &dest, const T &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles) {
+        variant payload_v;
+        to_variant(payload, payload_v);
+        return post_sync(dest, payload_v, deadline);
       }
 
       void add_cert(const std::string& cert_pem_string);

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -19,46 +19,46 @@ namespace {
 namespace fc {
 
 struct local_endpoint_resolver {
-  using tcp = boost::asio::ip::tcp;
-  using error_code = boost::system::error_code;
+   using tcp        = boost::asio::ip::tcp;
+   using error_code = boost::system::error_code;
 
-  local_endpoint_resolver(boost::asio::io_context &ctx)
-      : resolver(ctx), sock(ctx), timer(ctx) {}
-  tcp::resolver resolver;
-  tcp::socket sock;
-  boost::asio::deadline_timer timer;
-  std::string remote;
-  tcp::resolver::results_type endpoints;
-  std::optional<tcp::endpoint> local_endpoint;
+   local_endpoint_resolver(boost::asio::io_context& ctx)
+       : resolver(ctx)
+       , sock(ctx)
+       , timer(ctx) {}
+   boost::asio::io_context      ctx;
+   tcp::resolver                resolver;
+   tcp::socket                  sock;
+   boost::asio::deadline_timer  timer;
+   std::string                  remote;
+   tcp::resolver::results_type  endpoints;
+   std::optional<tcp::endpoint> local_endpoint;
 
-  void async_resolve(std::string remote_host, std::string port) {
-    remote = remote_host + ":" + port;
-    resolver.async_resolve(
-        remote_host, port,
-        [this](const error_code &ec, tcp::resolver::results_type resolved) {
-          if (ec)
+   void async_resolve(std::string remote_host, std::string port) {
+      remote = remote_host + ":" + port;
+      resolver.async_resolve(remote_host, port, [this](const error_code& ec, tcp::resolver::results_type resolved) {
+         if (ec)
             throw boost::system::system_error(ec);
-          endpoints = resolved;
-          do_connect();
-        });
-  }
+         endpoints = resolved;
+         do_connect();
+      });
+   }
 
-  void do_connect() {
-    boost::asio::async_connect(
-        sock, endpoints,
-        [this](const error_code &ec, const tcp::endpoint &endpoint) {
-          if (ec) {
+   void do_connect() {
+      boost::asio::async_connect(sock, endpoints, [this](const error_code& ec, const tcp::endpoint& endpoint) {
+         if (ec) {
             wlog("failed to connect to ${remote}, retry in 5 seconds", ("remote", remote));
             timer.expires_from_now(boost::posix_time::seconds(5));
-            timer.async_wait([this](const error_code &ec) {
-              if (!ec)
-                do_connect();
+            timer.async_wait([this](const error_code& ec) {
+               if (!ec)
+                  do_connect();
             });
             return;
-          }
-          local_endpoint = sock.local_endpoint();
-        });
-  }
+         }
+         local_endpoint = sock.local_endpoint();
+         ilog("connected to ${remote}", ("remote", remote));
+      });
+   }
 };
 
 zipkin_config& zipkin_config::get() {
@@ -141,10 +141,10 @@ void zipkin::impl::init(uint32_t wait_time_seconds) {
       if (!endpoint->host() || endpoint->host()->empty())
          FC_THROW("Invalid url ${url}", ("url", zipkin_url));
 
-      local_endpoint_resolver resolver(ctx);
+      local_endpoint_resolver resolver;
       resolver.async_resolve(*endpoint->host(), std::to_string(*endpoint->port()));
       auto deadline =  std::chrono::system_clock::now() + std::chrono::seconds(wait_time_seconds);
-      ctx.run_until(deadline);
+      resolver.ctx.run_until(deadline);
 
       local_endpoint = resolver.local_endpoint;
 
@@ -263,13 +263,13 @@ void zipkin::log( zipkin_span::span_data&& span ) {
 }
 
 void zipkin::impl::log( zipkin_span::span_data&& span ) {
-  if (consecutive_errors > max_consecutive_errors) {
-    wlog("consecutive_errors=${consecutive_errors} exceeds "
-         "limit($max_consecutive_errors)",
-         ("consecutive_errors", consecutive_errors.load())("max_consecutive_errors",
-                                                    max_consecutive_errors));
-    return;
-  }
+   if (consecutive_errors > max_consecutive_errors) {
+      wlog("consecutive_errors=${consecutive_errors} exceeds "
+            "limit($max_consecutive_errors)",
+            ("consecutive_errors", consecutive_errors.load())("max_consecutive_errors",
+                                                      max_consecutive_errors));
+      return;
+   }
 
    try {
       auto deadline = fc::time_point::now() + fc::microseconds( timeout_us );

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -22,7 +22,7 @@ struct local_endpoint_resolver {
    using tcp        = boost::asio::ip::tcp;
    using error_code = boost::system::error_code;
 
-   local_endpoint_resolver(boost::asio::io_context& ctx)
+   local_endpoint_resolver()
        : resolver(ctx)
        , sock(ctx)
        , timer(ctx) {}

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -142,16 +142,9 @@ fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::str
    //   int64_t     timestamp // epoch microseconds of start of span
    //   int64_t     duration  // microseconds of span
 
-   uint64_t trace_id;
-   if( span.parent_id != 0 ) {
-      trace_id = span.parent_id;
-   } else {
-      trace_id = span.id;
-   }
-
    fc::mutable_variant_object mvo;
    mvo( "id", fc::to_hex( reinterpret_cast<const char*>(&span.id), sizeof( span.id ) ) );
-   mvo( "traceId", fc::to_hex( reinterpret_cast<const char*>(&trace_id), sizeof( trace_id ) ) );
+   mvo( "traceId", fc::to_hex( reinterpret_cast<const char*>(&span.trace_id), sizeof( span.trace_id ) ) );
    if( span.parent_id != 0 ) {
       mvo( "parentId", fc::to_hex( reinterpret_cast<const char*>(&span.parent_id), sizeof( span.parent_id ) ) );
    }
@@ -202,8 +195,13 @@ void zipkin::log( zipkin_span::span_data&& span ) {
 }
 
 void zipkin::impl::log( zipkin_span::span_data&& span ) {
-   if( consecutive_errors > max_consecutive_errors )
-      return;
+  if (consecutive_errors > max_consecutive_errors) {
+    wlog("consecutive_errors=${consecutive_errors} exceeds "
+         "limit($max_consecutive_errors)",
+         ("consecutive_errors", consecutive_errors.load())("max_consecutive_errors",
+                                                    max_consecutive_errors));
+    return;
+  }
 
    try {
       auto deadline = fc::time_point::now() + fc::microseconds( timeout_us );
@@ -212,7 +210,7 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
          dlog( "connecting to zipkin: ${p}", ("p", *endpoint) );
       }
 
-      http.post_sync( *endpoint, create_zipkin_variant( std::move( span ), service_name ), deadline );
+      http.post_sync(*endpoint, create_zipkin_variant(std::move(span), service_name), deadline, fc::json::output_formatting::legacy_generator);
 
       consecutive_errors = 0;
       if (!connected){
@@ -245,6 +243,10 @@ zipkin_span::~zipkin_span() {
          zipkin_config::get_zipkin().log( std::move( data ) );
       }
    } catch( ... ) {}
+}
+
+std::string zipkin_span::trace_id_string() const {
+   return fc::to_hex(reinterpret_cast<const char *>(&data.trace_id), sizeof(data.trace_id));
 }
 
 } // fc

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -18,13 +18,57 @@ namespace {
 
 namespace fc {
 
+struct local_endpoint_resolver {
+  using tcp = boost::asio::ip::tcp;
+  using error_code = boost::system::error_code;
+
+  local_endpoint_resolver(boost::asio::io_context &ctx)
+      : resolver(ctx), sock(ctx), timer(ctx) {}
+  tcp::resolver resolver;
+  tcp::socket sock;
+  boost::asio::deadline_timer timer;
+  std::string remote;
+  tcp::resolver::results_type endpoints;
+  std::optional<tcp::endpoint> local_endpoint;
+
+  void async_resolve(std::string remote_host, std::string port) {
+    remote = remote_host + ":" + port;
+    resolver.async_resolve(
+        remote_host, port,
+        [this](const error_code &ec, tcp::resolver::results_type resolved) {
+          if (ec)
+            throw boost::system::system_error(ec);
+          endpoints = resolved;
+          do_connect();
+        });
+  }
+
+  void do_connect() {
+    boost::asio::async_connect(
+        sock, endpoints,
+        [this](const error_code &ec, const tcp::endpoint &endpoint) {
+          if (ec) {
+            std::cout << "failed to connect to " << remote
+                      << ", retry in 5 seconds\n";
+            timer.expires_from_now(boost::posix_time::seconds(5));
+            timer.async_wait([this](const error_code &ec) {
+              if (!ec)
+                do_connect();
+            });
+            return;
+          }
+          local_endpoint = sock.local_endpoint();
+        });
+  }
+};
+
 zipkin_config& zipkin_config::get() {
    static zipkin_config the_one;
    return the_one;
 }
 
-void zipkin_config::init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us ) {
-   get().zip = std::make_unique<zipkin>( url, service_name, timeout_us, retry_interval_us );
+void zipkin_config::init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us, uint32_t wait_time_seconds ) {
+   get().zip = std::make_unique<zipkin>( url, service_name, timeout_us, retry_interval_us, wait_time_seconds );
 }
 
 zipkin& zipkin_config::get_zipkin() {
@@ -74,6 +118,8 @@ public:
    boost::asio::deadline_timer timer{ctx};
    boost::asio::io_context::strand work_strand{ctx};
    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard = boost::asio::make_work_guard(ctx);
+   std::optional<boost::asio::ip::tcp::endpoint>  local_endpoint;
+
 
    impl( std::string url, std::string service_name, uint32_t timeout_us, uint32_t retry_interval_us )
          : zipkin_url( std::move(url) )
@@ -82,7 +128,7 @@ public:
          , retry_interval_us( retry_interval_us ) {
    }
 
-   void init();
+   void init(uint32_t wait_time_seconds);
    void shutdown();
 
    void log( zipkin_span::span_data&& span );
@@ -90,7 +136,24 @@ public:
    ~impl();
 };
 
-void zipkin::impl::init() {
+void zipkin::impl::init(uint32_t wait_time_seconds) {
+   if (wait_time_seconds > 0) {
+      endpoint = url( zipkin_url );
+      if (!endpoint->host() || endpoint->host()->empty())
+         FC_THROW("Invalid url ${url}", ("url", zipkin_url));
+
+      local_endpoint_resolver resolver(ctx);
+      resolver.async_resolve(*endpoint->host(), std::to_string(*endpoint->port()));
+      auto deadline =  std::chrono::system_clock::now() + std::chrono::seconds(wait_time_seconds);
+      ctx.run_until(deadline);
+
+      local_endpoint = resolver.local_endpoint;
+
+      if (!local_endpoint) {
+         FC_THROW("Unable to connect to ${url} within ${wait_time_seconds} seconds", ("url", zipkin_url)("wait_time_seconds", wait_time_seconds));
+      }
+   }
+
    thread = std::thread( [this]() {
       fc::set_os_thread_name( "zipkin" );
       while( true ) {
@@ -114,9 +177,9 @@ void zipkin::impl::shutdown() {
    thread.join();
 }
 
-zipkin::zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us ) :
+zipkin::zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us, uint32_t wait_time_seconds  ) :
       my( new impl( url, service_name, timeout_us, retry_interval_us ) ) {
-   my->init();
+   my->init(wait_time_seconds);
 }
 
 uint64_t zipkin::get_next_unique_id() {
@@ -133,7 +196,7 @@ void zipkin::shutdown() {
    my->shutdown();
 }
 
-fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::string& service_name ) {
+fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::string& service_name, std::optional<boost::asio::ip::tcp::endpoint>& local_endpoint ) {
    // https://zipkin.io/zipkin-api/
    //   std::string traceId;  // [a-f0-9]{16,32} unique id for trace, all children spans shared same id
    //   std::string name;     // logical operation, should have low cardinality
@@ -151,7 +214,13 @@ fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::str
    mvo( "name", std::move( span.name ) );
    mvo( "timestamp", span.start.time_since_epoch().count() );
    mvo( "duration", (span.stop - span.start).count() );
-   mvo( "localEndpoint", fc::variant_object( "serviceName", service_name ) );
+
+   mutable_variant_object local_endpoint_mvo("serviceName", service_name);
+   if (local_endpoint) {
+      const auto &address = local_endpoint->address();
+      local_endpoint_mvo( address.is_v4() ? "ipv4": "ipv6", address.to_string());
+   }
+   mvo( "localEndpoint", local_endpoint_mvo );
 
    mvo( "tags", std::move( span.tags ) );
    span.id = 0; // stop destructor of span from calling log again
@@ -210,7 +279,7 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
          dlog( "connecting to zipkin: ${p}", ("p", *endpoint) );
       }
 
-      http.post_sync(*endpoint, create_zipkin_variant(std::move(span), service_name), deadline, fc::json::output_formatting::legacy_generator);
+      http.post_sync(*endpoint, create_zipkin_variant(std::move(span), service_name, local_endpoint), deadline, fc::json::output_formatting::legacy_generator);
 
       consecutive_errors = 0;
       if (!connected){

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -48,8 +48,7 @@ struct local_endpoint_resolver {
         sock, endpoints,
         [this](const error_code &ec, const tcp::endpoint &endpoint) {
           if (ec) {
-            std::cout << "failed to connect to " << remote
-                      << ", retry in 5 seconds\n";
+            wlog("failed to connect to ${remote}, retry in 5 seconds", ("remote", remote));
             timer.expires_from_now(boost::posix_time::seconds(5));
             timer.async_wait([this](const error_code &ec) {
               if (!ec)

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -314,7 +314,7 @@ public:
       const deadline_type&               deadline;
    };
 
-variant
+   variant
    post_sync(const url &dest, const variant &payload,
              const fc::time_point &_deadline,
              json::output_formatting formatting) {
@@ -453,13 +453,16 @@ http_client::http_client()
 
 }
 
-variant http_client::post_sync(const url& dest, const variant& payload, const fc::time_point& deadline) {
+variant http_client::post_sync(const url &dest, const variant &payload,
+                               const fc::time_point &deadline,
+                               json::output_formatting formatting) {
 #ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
-   if(dest.proto() == "unix")
-      return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline);
-   else
+  if (dest.proto() == "unix")
+    return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline,
+                          formatting);
 #endif
-      return _my->post_sync(dest, payload, deadline);
+  else
+    return _my->post_sync(dest, payload, deadline, formatting);
 }
 
 void http_client::add_cert(const std::string& cert_pem_string) {

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -314,7 +314,10 @@ public:
       const deadline_type&               deadline;
    };
 
-   variant post_sync(const url& dest, const variant& payload, const fc::time_point& _deadline) {
+variant
+   post_sync(const url &dest, const variant &payload,
+             const fc::time_point &_deadline,
+             json::output_formatting formatting) {
       static const deadline_type epoch(boost::gregorian::date(1970, 1, 1));
       auto deadline = epoch + boost::posix_time::microseconds(_deadline.time_since_epoch().count());
       FC_ASSERT(dest.host(), "No host set on URL");
@@ -338,7 +341,7 @@ public:
       req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
       req.set(http::field::content_type, "application/json");
       req.keep_alive(true);
-      req.body() = json::to_string(payload, _deadline);
+      req.body() = json::to_string(payload, _deadline, formatting);
       req.prepare_payload();
 
       auto conn_iter = get_connection(dest, deadline);
@@ -393,6 +396,8 @@ public:
          }
       } else if (res.result() == http::status::not_found) {
          FC_THROW("URL not found: ${url}", ("url", (std::string)dest));
+      } else if (res.result() == http::status::bad_request) {
+         FC_THROW("Received request: ${msg}", ("msg", res.body()));
       }
 
       return result;


### PR DESCRIPTION
The PR implement the functionality to create nested zipkin spans and some other improvements:

change macros to inline functions
* add warning messages to indicate why spans are no longer sending to the zipkin collector
* add create_trace_with_start_time for tracking some async operations
* use lagacy format for json encoding to be able to interoperate with Jaeger collector
* add fc_trace_log to correlate zipkin traces with log messages.
* add wait time option to wait until zipkin is available, throws exception otherwise. This is useful to guard against zipkin URL configuration error. 