### PR TITLE
zipkin improvement

### DIFF
--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -1,44 +1,85 @@
 #pragma once
 
 #include <fc/log/zipkin.hpp>
+#include <fc/log/logger.hpp>
 #include <optional>
 
-/// @param TRACE_STR const char* identifier for trace
+/// @param trace_str const char* identifier for trace
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace( TRACE_STR ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace(const char* trace_str) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_config::get_next_unique_id(),
+                                                   (trace_str), 0, 0)
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_STR const char* identifier for trace
-/// @param TRACE_ID fc::sha256 id to use
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
 /// @return implementation defined type RAII object that submits trace on exit of scope
-#define fc_create_trace_with_id( TRACE_STR, TRACE_ID ) \
-      ::fc::zipkin_config::is_enabled() ? \
-        ::fc::optional_trace{ ::std::optional<::fc::zipkin_trace>( ::std::in_place, ::fc::zipkin_span::to_id(TRACE_ID), (TRACE_STR) ) } \
-        : ::fc::optional_trace{};
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id(const char* trace_str, const fc::sha256& trace_id) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), 0 , 0)
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_VARNAME variable returned from fc_create_trace
-/// @param SPAN_STR const char* indentifier
+/// @param condition create the trace only when the condition is true
+/// @param trace_str const char* identifier for trace
+/// @param trace_id fc::sha256 id to use
+/// @return implementation defined type RAII object that submits trace on exit of scope
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_id_if(bool condition, const char* trace_str, const fc::sha256& trace_id) {
+   return (condition && ::fc::zipkin_config::is_enabled())
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, ::fc::zipkin_span::to_id(trace_id), (trace_str), ::fc::zipkin_span::to_id(trace_id) , 0)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+inline ::std::optional<::fc::zipkin_span> fc_create_span_with_id(const char* span_str, uint64_t id, const fc::sha256& trace_id) {
+   auto tid = ::fc::zipkin_span::to_id(trace_id);
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, id, span_str, tid, tid)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+inline ::std::optional<::fc::zipkin_span> fc_create_trace_with_start_time(const char* trace_str, fc::time_point start) {
+   return ::fc::zipkin_config::is_enabled()
+              ? ::std::optional<::fc::zipkin_span>(::std::in_place, trace_str, start)
+              : ::std::optional<::fc::zipkin_span>{};
+}
+
+/// @param trace variable returned from fc_create_trace
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span( TRACE_VARNAME, SPAN_STR ) \
-      ( (TRACE_VARNAME) && ::fc::zipkin_config::is_enabled() ) ? \
-        (TRACE_VARNAME).opt->create_span( (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span(const ::std::optional<::fc::zipkin_span>& trace,
+                                                         const char*                               span_str) {
+   return ((trace) && ::fc::zipkin_config::is_enabled()) ? (trace)->create_span((span_str))
+                                                         : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param TRACE_TOKEN variable returned from trace.get_token()
-/// @param SPAN_STR const char* indentifier
+/// @param trace_token variable returned from trace.get_token()
+/// @param span_str const char* indentifier
 /// @return implementation defined type RAII object that submits span on exit of scope
-#define fc_create_span_from_token( TRACE_TOKEN, SPAN_STR ) \
-      ( (TRACE_TOKEN) && ::fc::zipkin_config::is_enabled() ) ? \
-        ::fc::zipkin_trace::create_span_from_token( (TRACE_TOKEN), (SPAN_STR) ) \
-        : ::std::optional<::fc::zipkin_span>{};
+inline ::std::optional<::fc::zipkin_span> fc_create_span_from_token(fc::zipkin_span::token trace_token,
+                                                                    const char*            span_str) {
+   return ((trace_token) && ::fc::zipkin_config::is_enabled())
+              ? ::fc::zipkin_span::create_span_from_token((trace_token), (span_str))
+              : ::std::optional<::fc::zipkin_span>{};
+}
 
-/// @param SPAN_VARNAME variable returned from fc_create_span
-/// @param TAG_KEY_STR string key
-/// @param TAG_VALUE string value
-#define fc_add_tag( SPAN_VARNAME, TAG_KEY_STR, TAG_VALUE_STR) \
+/// @param span variable returned from fc_create_span
+/// @param tag_key_str string key
+/// @param tag_value string value
+template <typename Value>
+inline void fc_add_tag(::std::optional<::fc::zipkin_span>& span, const char* tag_key_str, Value&& value) {
+   if ((span) && ::fc::zipkin_config::is_enabled())
+      (span)->add_tag((tag_key_str), std::forward<Value>(value));
+}
+
+inline fc::zipkin_span::token fc_get_token(const ::std::optional<::fc::zipkin_span>& span) {
+   return (span && ::fc::zipkin_config::is_enabled()) ? span->get_token() : fc::zipkin_span::token(0, 0);
+}
+
+
+#define fc_trace_log( TRACE_OR_SPAN, FORMAT, ... ) \
   FC_MULTILINE_MACRO_BEGIN \
-      if( (SPAN_VARNAME) && ::fc::zipkin_config::is_enabled() ) \
-         (SPAN_VARNAME)->add_tag( (TAG_KEY_STR), (TAG_VALUE_STR) ); \
+   if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::info ) ) \
+      (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( info, FORMAT " traceID=${_the_trace_id_}", ("_the_trace_id_", TRACE_OR_SPAN->trace_id_string()) __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END

--- a/include/fc/network/http/http_client.hpp
+++ b/include/fc/network/http/http_client.hpp
@@ -9,6 +9,7 @@
 #include <fc/variant.hpp>
 #include <fc/exception/exception.hpp>
 #include <fc/network/url.hpp>
+#include <fc/io/json.hpp>
 
 namespace fc {
 
@@ -17,13 +18,21 @@ class http_client {
       http_client();
       ~http_client();
 
-      variant post_sync(const url& dest, const variant& payload, const time_point& deadline = time_point::maximum());
+      variant
+      post_sync(const url &dest, const variant &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles);
 
-      template<typename T>
-      variant post_sync(const url& dest, const T& payload, const time_point& deadline = time_point::maximum()) {
-         variant payload_v;
-         to_variant(payload, payload_v);
-         return post_sync(dest, payload_v, deadline);
+      template <typename T>
+      variant
+      post_sync(const url &dest, const T &payload,
+                const time_point &deadline = time_point::maximum(),
+                json::output_formatting formatting =
+                    json::output_formatting::stringify_large_ints_and_doubles) {
+        variant payload_v;
+        to_variant(payload, payload_v);
+        return post_sync(dest, payload_v, deadline, formatting);
       }
 
       void add_cert(const std::string& cert_pem_string);

--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -18,13 +18,56 @@ namespace {
 
 namespace fc {
 
+struct local_endpoint_resolver {
+   using tcp        = boost::asio::ip::tcp;
+   using error_code = boost::system::error_code;
+
+   local_endpoint_resolver()
+       : resolver(ctx)
+       , sock(ctx)
+       , timer(ctx) {}
+   boost::asio::io_context      ctx;
+   tcp::resolver                resolver;
+   tcp::socket                  sock;
+   boost::asio::deadline_timer  timer;
+   std::string                  remote;
+   tcp::resolver::results_type  endpoints;
+   std::optional<tcp::endpoint> local_endpoint;
+
+   void async_resolve(std::string remote_host, std::string port) {
+      remote = remote_host + ":" + port;
+      resolver.async_resolve(remote_host, port, [this](const error_code& ec, tcp::resolver::results_type resolved) {
+         if (ec)
+            throw boost::system::system_error(ec);
+         endpoints = resolved;
+         do_connect();
+      });
+   }
+
+   void do_connect() {
+      boost::asio::async_connect(sock, endpoints, [this](const error_code& ec, const tcp::endpoint& endpoint) {
+         if (ec) {
+            wlog("failed to connect to ${remote}, retry in 5 seconds", ("remote", remote));
+            timer.expires_from_now(boost::posix_time::seconds(5));
+            timer.async_wait([this](const error_code& ec) {
+               if (!ec)
+                  do_connect();
+            });
+            return;
+         }
+         local_endpoint = sock.local_endpoint();
+         ilog("connected to ${remote}", ("remote", remote));
+      });
+   }
+};
+
 zipkin_config& zipkin_config::get() {
    static zipkin_config the_one;
    return the_one;
 }
 
-void zipkin_config::init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us ) {
-   get().zip = std::make_unique<zipkin>( url, service_name, timeout_us, retry_interval_us );
+void zipkin_config::init( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us, uint32_t wait_time_seconds ) {
+   get().zip = std::make_unique<zipkin>( url, service_name, timeout_us, retry_interval_us, wait_time_seconds );
 }
 
 zipkin& zipkin_config::get_zipkin() {
@@ -74,6 +117,8 @@ public:
    boost::asio::deadline_timer timer{ctx};
    boost::asio::io_context::strand work_strand{ctx};
    boost::asio::executor_work_guard<boost::asio::io_context::executor_type> work_guard = boost::asio::make_work_guard(ctx);
+   std::optional<boost::asio::ip::tcp::endpoint>  local_endpoint;
+
 
    impl( std::string url, std::string service_name, uint32_t timeout_us, uint32_t retry_interval_us )
          : zipkin_url( std::move(url) )
@@ -82,7 +127,7 @@ public:
          , retry_interval_us( retry_interval_us ) {
    }
 
-   void init();
+   void init(uint32_t wait_time_seconds);
    void shutdown();
 
    void log( zipkin_span::span_data&& span );
@@ -90,7 +135,24 @@ public:
    ~impl();
 };
 
-void zipkin::impl::init() {
+void zipkin::impl::init(uint32_t wait_time_seconds) {
+   if (wait_time_seconds > 0) {
+      endpoint = url( zipkin_url );
+      if (!endpoint->host() || endpoint->host()->empty())
+         FC_THROW("Invalid url ${url}", ("url", zipkin_url));
+
+      local_endpoint_resolver resolver;
+      resolver.async_resolve(*endpoint->host(), std::to_string(*endpoint->port()));
+      auto deadline =  std::chrono::system_clock::now() + std::chrono::seconds(wait_time_seconds);
+      resolver.ctx.run_until(deadline);
+
+      local_endpoint = resolver.local_endpoint;
+
+      if (!local_endpoint) {
+         FC_THROW("Unable to connect to ${url} within ${wait_time_seconds} seconds", ("url", zipkin_url)("wait_time_seconds", wait_time_seconds));
+      }
+   }
+
    thread = std::thread( [this]() {
       fc::set_os_thread_name( "zipkin" );
       while( true ) {
@@ -116,9 +178,9 @@ void zipkin::impl::shutdown() {
    thread.join();
 }
 
-zipkin::zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us ) :
+zipkin::zipkin( const std::string& url, const std::string& service_name, uint32_t timeout_us, uint32_t retry_interval_us, uint32_t wait_time_seconds  ) :
       my( new impl( url, service_name, timeout_us, retry_interval_us ) ) {
-   my->init();
+   my->init(wait_time_seconds);
 }
 
 uint64_t zipkin::get_next_unique_id() {
@@ -135,7 +197,7 @@ void zipkin::shutdown() {
    my->shutdown();
 }
 
-fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::string& service_name ) {
+fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::string& service_name, std::optional<boost::asio::ip::tcp::endpoint>& local_endpoint ) {
    // https://zipkin.io/zipkin-api/
    //   std::string traceId;  // [a-f0-9]{16,32} unique id for trace, all children spans shared same id
    //   std::string name;     // logical operation, should have low cardinality
@@ -144,23 +206,22 @@ fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::str
    //   int64_t     timestamp // epoch microseconds of start of span
    //   int64_t     duration  // microseconds of span
 
-   uint64_t trace_id;
-   if( span.parent_id != 0 ) {
-      trace_id = span.parent_id;
-   } else {
-      trace_id = span.id;
-   }
-
    fc::mutable_variant_object mvo;
    mvo( "id", fc::to_hex( reinterpret_cast<const char*>(&span.id), sizeof( span.id ) ) );
-   mvo( "traceId", fc::to_hex( reinterpret_cast<const char*>(&trace_id), sizeof( trace_id ) ) );
+   mvo( "traceId", fc::to_hex( reinterpret_cast<const char*>(&span.trace_id), sizeof( span.trace_id ) ) );
    if( span.parent_id != 0 ) {
       mvo( "parentId", fc::to_hex( reinterpret_cast<const char*>(&span.parent_id), sizeof( span.parent_id ) ) );
    }
    mvo( "name", std::move( span.name ) );
    mvo( "timestamp", span.start.time_since_epoch().count() );
    mvo( "duration", (span.stop - span.start).count() );
-   mvo( "localEndpoint", fc::variant_object( "serviceName", service_name ) );
+
+   mutable_variant_object local_endpoint_mvo("serviceName", service_name);
+   if (local_endpoint) {
+      const auto &address = local_endpoint->address();
+      local_endpoint_mvo( address.is_v4() ? "ipv4": "ipv6", address.to_string());
+   }
+   mvo( "localEndpoint", local_endpoint_mvo );
 
    mvo( "tags", std::move( span.tags ) );
    span.id = 0; // stop destructor of span from calling log again
@@ -205,8 +266,13 @@ void zipkin::log( zipkin_span::span_data&& span ) {
 }
 
 void zipkin::impl::log( zipkin_span::span_data&& span ) {
-   if( consecutive_errors > max_consecutive_errors )
+   if (consecutive_errors > max_consecutive_errors) {
+      wlog("consecutive_errors=${consecutive_errors} exceeds "
+            "limit($max_consecutive_errors)",
+            ("consecutive_errors", consecutive_errors.load())("max_consecutive_errors",
+                                                      max_consecutive_errors));
       return;
+   }
 
    try {
       auto deadline = fc::time_point::now() + fc::microseconds( timeout_us );
@@ -215,7 +281,7 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
          dlog( "connecting to zipkin: ${p}", ("p", *endpoint) );
       }
 
-      http.post_sync( *endpoint, create_zipkin_variant( std::move( span ), service_name ), deadline );
+      http.post_sync(*endpoint, create_zipkin_variant(std::move(span), service_name, local_endpoint), deadline, fc::json::output_formatting::legacy_generator);
 
       consecutive_errors = 0;
       if (!connected){
@@ -248,6 +314,10 @@ zipkin_span::~zipkin_span() {
          zipkin_config::get_zipkin().log( std::move( data ) );
       }
    } catch( ... ) {}
+}
+
+std::string zipkin_span::trace_id_string() const {
+   return fc::to_hex(reinterpret_cast<const char *>(&data.trace_id), sizeof(data.trace_id));
 }
 
 } // fc

--- a/src/network/http/http_client.cpp
+++ b/src/network/http/http_client.cpp
@@ -300,7 +300,10 @@ public:
       const deadline_type&               deadline;
    };
 
-   variant post_sync(const url& dest, const variant& payload, const fc::time_point& _deadline) {
+   variant
+   post_sync(const url &dest, const variant &payload,
+             const fc::time_point &_deadline,
+             json::output_formatting formatting) {
       static const deadline_type epoch(boost::gregorian::date(1970, 1, 1));
       auto deadline = epoch + boost::posix_time::microseconds(_deadline.time_since_epoch().count());
       FC_ASSERT(dest.host(), "No host set on URL");
@@ -324,7 +327,7 @@ public:
       req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
       req.set(http::field::content_type, "application/json");
       req.keep_alive(true);
-      req.body() = json::to_string(payload, _deadline);
+      req.body() = json::to_string(payload, _deadline, formatting);
       req.prepare_payload();
 
       auto conn_iter = get_connection(dest, deadline);
@@ -379,6 +382,8 @@ public:
          }
       } else if (res.result() == http::status::not_found) {
          FC_THROW("URL not found: ${url}", ("url", (std::string)dest));
+      } else if (res.result() == http::status::bad_request) {
+         FC_THROW("Received request: ${msg}", ("msg", res.body()));
       }
 
       return result;
@@ -432,11 +437,12 @@ http_client::http_client()
 
 }
 
-variant http_client::post_sync(const url& dest, const variant& payload, const fc::time_point& deadline) {
-   if(dest.proto() == "unix")
-      return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline);
+variant http_client::post_sync(const url& dest, const variant& payload, const fc::time_point& deadline,
+                               json::output_formatting formatting) {
+   if (dest.proto() == "unix")
+      return _my->post_sync(_my->get_unix_url(*dest.host()), payload, deadline, formatting);
    else
-      return _my->post_sync(dest, payload, deadline);
+      return _my->post_sync(dest, payload, deadline, formatting);
 }
 
 void http_client::add_cert(const std::string& cert_pem_string) {


### PR DESCRIPTION
The PR implement the functionality to create nested zipkin spans and some other improvements:

- change macros to inline functions
- add warning messages to indicate why spans are no longer sending to the zipkin collector
- add create_trace_with_start_time for tracking some async operations
- use lagacy format for json encoding to be able to interoperate with Jaeger collector
- add fc_trace_log to correlate zipkin traces with log messages.
- add wait_time_seconds configuration options for the initial wait time to connect to zipkin collector