### PR TITLE
Add boost header include for specializing boost::hash

### DIFF
--- a/include/fc/crypto/sha256.hpp
+++ b/include/fc/crypto/sha256.hpp
@@ -3,6 +3,7 @@
 #include <fc/string.hpp>
 #include <fc/platform_independence.hpp>
 #include <fc/io/raw_fwd.hpp>
+#include <boost/container_hash/hash.hpp>
 
 namespace fc
 {


### PR DESCRIPTION
In `include/fc/crypto/sha256.hpp` we specialized `boost::hash<>` without properly including the Boost header `<boost/container_hash/hash.hpp>`.

https://github.com/EOSIO/fc/blob/0793fbe8262973b6707638dac9c6aaaf4913194e/include/fc/crypto/sha256.hpp#L125-L130

This PR includes the above header.

The previous success of the fc build might have relied on some cross-inclusion among the Boost headers. However, while this is still okay with Boost `1.76`, the fc library build starts to fail with the latest Boost `1.77` version (built on a Ubuntu 18.04 machine with g++-8) reporting the following errors:

```
.../external/fc/include/fc/crypto/sha256.hpp:127:12: error: ‘hash’ is not a class template
     struct hash<fc::sha256>
            ^~~~
.../external/fc/include/fc/crypto/sha256.hpp:128:5: error: explicit specialization of non-template ‘boost::hash’
     {
     ^
```

Considering that the current EOSIO software mostly depends on Boost `1.72`, it is still okay for the fc library for the time being. But the problem might surface if we will upgrade to `1.77` or later.
