### PR TITLE
Fix deepmind log not reset properly 2.2.x

### DIFF
--- a/src/log/dmlog_appender.cpp
+++ b/src/log/dmlog_appender.cpp
@@ -31,6 +31,9 @@ namespace fc {
 
    void dmlog_appender::initialize( boost::asio::io_service& io_service ) {
       my->io_service = &io_service;
+      // Reset in case of resources somehow being held by mutex lock even when nodeos is shutdown
+      // which might cause logger to print wrong DMLOG if is_stopped is true in previous run
+      my->is_stopped = false;
    }
 
    void dmlog_appender::log( const log_message& m ) {


### PR DESCRIPTION
When start and stop nodeos with deepmind enabled, there will be a chance that is_stopped being held, and if is_stopped = true, this will cause and next run to return true and only print out DMLOG FPRINTF_FAILURE_TERMINATED for all deepmind log.