### PR TITLE
fix gcc warnings

### DIFF
--- a/include/fc/array.hpp
+++ b/include/fc/array.hpp
@@ -116,7 +116,7 @@ namespace fc {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi.data, char(0), sizeof(bi.data) );
   }
 
 

--- a/include/fc/exception/exception.hpp
+++ b/include/fc/exception/exception.hpp
@@ -477,10 +477,8 @@ namespace fc
       wdump( __VA_ARGS__ ); \
    }
 
-#define FC_LOG_AND_DROP( ... )  \
-   catch( const boost::interprocess::bad_alloc& ) {\
-      throw;\
-   } catch( fc::exception& er ) { \
+#define FC_LOG_AND_DROP_ALL( ... )  \
+   catch( fc::exception& er ) { \
       wlog( "${details}", ("details",er.to_detail_string()) ); \
    } catch( const std::exception& e ) {  \
       fc::std_exception_wrapper sew( \
@@ -495,6 +493,12 @@ namespace fc
                 std::current_exception() ); \
       wlog( "${details}", ("details",e.to_detail_string()) ); \
    }
+
+
+#define FC_LOG_AND_DROP( ... )  \
+   catch( const boost::interprocess::bad_alloc& ) {\
+      throw;\
+   } FC_LOG_AND_DROP_ALL(__VA_ARGS__)
 
 
 /**

--- a/include/fc/log/trace.hpp
+++ b/include/fc/log/trace.hpp
@@ -83,3 +83,4 @@ inline fc::zipkin_span::token fc_get_token(const ::std::optional<::fc::zipkin_sp
    if( (fc::logger::get(DEFAULT_LOGGER)).is_enabled( fc::log_level::info ) ) \
       (fc::logger::get(DEFAULT_LOGGER)).log( FC_LOG_MESSAGE( info, FORMAT " traceID=${_the_trace_id_}", ("_the_trace_id_", TRACE_OR_SPAN->trace_id_string()) __VA_ARGS__ ) ); \
   FC_MULTILINE_MACRO_END
+  

--- a/src/compress/miniz.c
+++ b/src/compress/miniz.c
@@ -2287,7 +2287,10 @@ static MZ_FORCEINLINE void tdefl_find_match(tdefl_compressor *d, mz_uint lookahe
         if (TDEFL_READ_UNALIGNED_WORD(&d->m_dict[probe_pos + match_len - 1]) == c01) break;
       TDEFL_PROBE; TDEFL_PROBE; TDEFL_PROBE;
     }
-    if (!dist) break; q = (const mz_uint16*)(d->m_dict + probe_pos); if (TDEFL_READ_UNALIGNED_WORD(q) != s01) continue; p = s; probe_len = 32;
+    if (!dist) break; 
+    q = (const mz_uint16*)(d->m_dict + probe_pos); 
+    if (TDEFL_READ_UNALIGNED_WORD(q) != s01) continue; 
+    p = s; probe_len = 32;
     do { } while ( (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) &&
                    (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (TDEFL_READ_UNALIGNED_WORD(++p) == TDEFL_READ_UNALIGNED_WORD(++q)) && (--probe_len > 0) );
     if (!probe_len)

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -382,6 +382,8 @@ std::vector<char> aes_load( const fc::path& file, const fc::sha512& key )
    return aes_decrypt( key, cipher );
 } FC_RETHROW_EXCEPTIONS( warn, "", ("file",file) ) }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+
 /* This stuff has to go somewhere, I guess this is as good a place as any...
   OpenSSL isn't thread-safe unless you give it access to some mutexes,
   so the CRYPTO_set_id_callback() function needs to be called before there's any
@@ -441,5 +443,5 @@ openssl_thread_config::~openssl_thread_config()
     openssl_mutexes = nullptr;
   }
 }
-
+#endif
 }  // namespace fc

--- a/src/crypto/elliptic_webauthn.cpp
+++ b/src/crypto/elliptic_webauthn.cpp
@@ -89,6 +89,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case IN_NESTED_CONTAINER:
             return true;
       }
+      __builtin_unreachable();
    }
 
    bool StartObject() {
@@ -109,6 +110,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_TYPE_VALUE:
             return false;
       }
+      __builtin_unreachable();
    }
    bool Key(const char* str, rapidjson::SizeType length, bool copy) {
       switch(current_state) {
@@ -132,6 +134,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case IN_NESTED_CONTAINER:
             return true;
       }
+      __builtin_unreachable();
    }
    bool EndObject(rapidjson::SizeType memberCount) {
       switch(current_state) {
@@ -148,6 +151,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_FIRST_OBJECT_KEY:
             return true;
       }
+      __builtin_unreachable();
    }
 
    bool StartArray() {
@@ -166,6 +170,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
          case EXPECT_TYPE_VALUE:
             return false;
       }
+      __builtin_unreachable();
    }
    bool EndArray(rapidjson::SizeType elementCount) {
       switch(current_state) {
@@ -181,6 +186,7 @@ struct webauthn_json_handler : public rapidjson::BaseReaderHandler<rapidjson::UT
                current_state = EXPECT_FIRST_OBJECT_KEY;
             return true;
       }
+      __builtin_unreachable();
    }
 };
 } //detail

--- a/src/crypto/openssl.cpp
+++ b/src/crypto/openssl.cpp
@@ -37,9 +37,10 @@ namespace  fc
        }
        openssl_scope()
        {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
           ERR_load_crypto_strings(); 
           OpenSSL_add_all_algorithms();
-
+#endif
           const boost::filesystem::path& boostPath = config_path();
           if(boostPath.empty() == false)
           {
@@ -52,14 +53,19 @@ namespace  fc
 #endif
           }
 
-          OPENSSL_config(nullptr);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+ 	       OPENSSL_config(nullptr);
+#else
+	       OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CONFIG, NULL);
+#endif
        }
-
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
        ~openssl_scope()
        {
           EVP_cleanup();
           ERR_free_strings();
        }
+#endif           
     };
 
 

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -112,7 +112,7 @@ bool operator == ( const ripemd160& h1, const ripemd160& h2 ) {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi._hash, char(0), sizeof(bi._hash) );
   }
 
 } // fc

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -98,7 +98,7 @@ bool operator == ( const sha1& h1, const sha1& h2 ) {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi._hash, char(0), sizeof(bi._hash) );
   }
 
 } // fc

--- a/src/crypto/sha224.cpp
+++ b/src/crypto/sha224.cpp
@@ -93,7 +93,7 @@ namespace fc {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi._hash, char(0), sizeof(bi._hash) );
   }
 
     template<>

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -215,7 +215,7 @@ namespace fc {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi._hash, char(0), sizeof(bi._hash) );
   }
 
   uint64_t hash64(const char* buf, size_t len)

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -100,7 +100,7 @@ namespace fc {
         memcpy(&bi, ve.data(), fc::min<size_t>(ve.size(),sizeof(bi)) );
     }
     else
-        memset( &bi, char(0), sizeof(bi) );
+        memset( bi._hash, char(0), sizeof(bi._hash) );
   }
 
     template<>


### PR DESCRIPTION
This PR fixes numerous gcc warnings
- Remove openssl version 1.0.x support,
- adds `FC_LOG_AND_DROP_ALL` macro which does not throw any exception (to be used by EOS),
- adds `__builtin_unreachable()` after `switch` statement when all cases have been returned,
- avoids `memset` on non-POD object warnings.
