### PR TITLE
Fix segfault on shutdown and reduce log spam - eosio

### DIFF
--- a/src/log/zipkin.cpp
+++ b/src/log/zipkin.cpp
@@ -171,7 +171,7 @@ zipkin::impl::~impl() {
 }
 
 void zipkin::impl::shutdown() {
-   if( stopped ^= 1 ) return;
+   if( stopped.exchange(1) ) return;
    boost::system::error_code ec;
    timer.cancel(ec);
    work_guard.reset(); // drain the queue
@@ -234,7 +234,7 @@ fc::variant create_zipkin_variant( zipkin_span::span_data&& span, const std::str
 }
 
 void zipkin::post_request(zipkin_span::span_data&& span) {
-   boost::asio::post(my->work_strand, [this, span{std::move(span)}]() mutable {
+   boost::asio::post(my->work_strand, [my=my.get(), span{std::move(span)}]() mutable {
          my->log( std::move( span ) );
    });
 }
@@ -266,14 +266,18 @@ void zipkin::log( zipkin_span::span_data&& span ) {
 }
 
 void zipkin::impl::log( zipkin_span::span_data&& span ) {
-   if (consecutive_errors > max_consecutive_errors) {
-      wlog("consecutive_errors=${consecutive_errors} exceeds "
-            "limit($max_consecutive_errors)",
-            ("consecutive_errors", consecutive_errors.load())("max_consecutive_errors",
-                                                      max_consecutive_errors));
+   auto errors = consecutive_errors.load();
+   if ((errors > max_consecutive_errors) || (stopped && errors > 1)) {
+      if( errors < max_consecutive_errors + 5) { // reduce log spam
+         wlog("errors=${consecutive_errors} > limit(${max_consecutive_errors}) dropping: ${span}",
+              ("consecutive_errors", errors)("max_consecutive_errors", max_consecutive_errors)
+              ("span", create_zipkin_variant(std::move(span), service_name, local_endpoint)));
+      }
+      ++consecutive_errors;
       return;
    }
 
+   fc::variant zip_span;
    try {
       auto deadline = fc::time_point::now() + fc::microseconds( timeout_us );
       if( !endpoint ) {
@@ -281,7 +285,8 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
          dlog( "connecting to zipkin: ${p}", ("p", *endpoint) );
       }
 
-      http.post_sync(*endpoint, create_zipkin_variant(std::move(span), service_name, local_endpoint), deadline, fc::json::output_formatting::legacy_generator);
+      zip_span = create_zipkin_variant(std::move(span), service_name, local_endpoint);
+      http.post_sync(*endpoint, zip_span, deadline, fc::json::output_formatting::legacy_generator);
 
       consecutive_errors = 0;
       if (!connected){
@@ -290,11 +295,14 @@ void zipkin::impl::log( zipkin_span::span_data&& span ) {
       }
       return;
    } catch( const fc::exception& e ) {
-      wlog( "unable to connect to zipkin: ${u}, error: ${e}", ("u", zipkin_url)("e", e.to_detail_string()) );
+      wlog( "unable to connect to zipkin: ${u}, error: ${e}, dropping: ${s}",
+            ("u", zipkin_url)("e", e.to_detail_string())("s", zip_span) );
    } catch( const std::exception& e ) {
-      wlog( "unable to connect to zipkin: ${u}, error: ${e}", ("u", zipkin_url)("e", e.what()) );
+      wlog( "unable to connect to zipkin: ${u}, error: ${e}, dropping: ${s}",
+            ("u", zipkin_url)("e", e.what())("s", zip_span) );
    } catch( ... ) {
-      wlog( "unable to connect to zipkin: ${u}, error: unknown", ("u", zipkin_url) );
+      wlog( "unable to connect to zipkin: ${u}, error: unknown, dropping: ${s}",
+            ("u", zipkin_url)("s", zip_span) );
    }
    ++consecutive_errors;
    connected = false;


### PR DESCRIPTION
- nodeos was segfaulting on shutdown due to the captured `this` in `zipkin::post_request` which was no longer valid since zipkin object was already destroyed.
- Added additional information on what zipkin span is dropped on error.
- Reduced log spam when large number of unsent zipkin messages are queued up.